### PR TITLE
Update commands fix

### DIFF
--- a/lib/creator.js
+++ b/lib/creator.js
@@ -246,31 +246,29 @@ class SlashCreator extends eventemitter3_1.default {
             delete partialCommand.version;
             const command = this.commands.find((command) => !!(command.guildIDs && command.guildIDs.includes(guildID) && command.commandName === partialCommand.name));
             if (command) {
-                if (!lodash_1.isEqual(util_1.objectKeySort(partialCommand), util_1.objectKeySort(command.commandJSON))) {
-                    this.emit('debug', `Updating guild command "${applicationCommand.name}" (${applicationCommand.id}, guild: ${guildID})`);
-                    updatePayload.push({
-                        id: applicationCommand.id,
-                        ...command.commandJSON
-                    });
-                }
-                else {
-                    this.emit('debug', `Guild command "${applicationCommand.name}" (${applicationCommand.id}) synced (guild: ${guildID})`);
-                }
+                this.emit('debug', `Found guild command "${applicationCommand.name}" (${applicationCommand.id}, guild: ${guildID})`);
+                updatePayload.push({
+                    id: applicationCommand.id,
+                    ...command.commandJSON
+                });
                 handledCommands.push(command.keyName);
             }
             else if (deleteCommands) {
-                // Command is removed
                 this.emit('debug', `Removing guild command "${applicationCommand.name}" (${applicationCommand.id}, guild: ${guildID})`);
-                await this.api.deleteCommand(applicationCommand.id, guildID);
+            }
+            else {
+                updatePayload.push(applicationCommand);
             }
         }
-        if (updatePayload.length)
-            await this.api.updateCommands(updatePayload, guildID);
         const unhandledCommands = this.commands.filter((command) => !!(command.guildIDs && command.guildIDs.includes(guildID) && !handledCommands.includes(command.keyName)));
         for (const [, command] of unhandledCommands) {
             this.emit('debug', `Creating guild command "${command.commandName}" (guild: ${guildID})`);
-            await this.api.createCommand(command.commandJSON, guildID);
+            updatePayload.push({
+                ...command.commandJSON
+            });
         }
+        if (updatePayload.length)
+            await this.api.updateCommands(updatePayload, guildID);
     }
     /**
      * Sync global commands.
@@ -289,30 +287,29 @@ class SlashCreator extends eventemitter3_1.default {
             delete partialCommand.version;
             const command = this.commands.get(commandKey);
             if (command) {
-                if (!lodash_1.isEqual(util_1.objectKeySort(partialCommand), util_1.objectKeySort(command.commandJSON))) {
-                    this.emit('debug', `Updating command "${applicationCommand.name}" (${applicationCommand.id})`);
-                    updatePayload.push({
-                        id: applicationCommand.id,
-                        ...command.commandJSON
-                    });
-                }
-                else {
-                    this.emit('debug', `Command "${applicationCommand.name}" (${applicationCommand.id}) synced`);
-                }
+                this.emit('debug', `Found command "${applicationCommand.name}" (${applicationCommand.id})`);
+                updatePayload.push({
+                    id: applicationCommand.id,
+                    ...command.commandJSON
+                });
             }
             else if (deleteCommands) {
                 this.emit('debug', `Removing command "${applicationCommand.name}" (${applicationCommand.id})`);
-                await this.api.deleteCommand(applicationCommand.id);
+            }
+            else {
+                updatePayload.push(applicationCommand);
             }
             handledCommands.push(commandKey);
         }
-        if (updatePayload.length)
-            this.api.updateCommands(updatePayload);
         const unhandledCommands = this.commands.filter((command) => !command.guildIDs && !handledCommands.includes(command.keyName));
         for (const [, command] of unhandledCommands) {
             this.emit('debug', `Creating command "${command.commandName}"`);
-            await this.api.createCommand(command.commandJSON);
+            updatePayload.push({
+                ...command.commandJSON
+            });
         }
+        if (updatePayload.length)
+            this.api.updateCommands(updatePayload);
     }
     _getCommandFromInteraction(interaction) {
         return 'guild_id' in interaction

--- a/src/creator.ts
+++ b/src/creator.ts
@@ -388,16 +388,16 @@ class SlashCreator extends ((EventEmitter as any) as new () => TypedEmitter<Slas
             'debug',
             `Updating guild command "${applicationCommand.name}" (${applicationCommand.id}, guild: ${guildID})`
           );
-          updatePayload.push({
-            id: applicationCommand.id,
-            ...command.commandJSON
-          });
         } else {
           this.emit(
             'debug',
             `Guild command "${applicationCommand.name}" (${applicationCommand.id}) synced (guild: ${guildID})`
           );
         }
+        updatePayload.push({
+          id: applicationCommand.id,
+          ...command.commandJSON
+        });
         handledCommands.push(command.keyName);
       } else if (deleteCommands) {
         // Command is removed
@@ -443,13 +443,13 @@ class SlashCreator extends ((EventEmitter as any) as new () => TypedEmitter<Slas
       if (command) {
         if (!isEqual(objectKeySort(partialCommand), objectKeySort(command.commandJSON))) {
           this.emit('debug', `Updating command "${applicationCommand.name}" (${applicationCommand.id})`);
-          updatePayload.push({
-            id: applicationCommand.id,
-            ...command.commandJSON
-          });
         } else {
           this.emit('debug', `Command "${applicationCommand.name}" (${applicationCommand.id}) synced`);
         }
+        updatePayload.push({
+          id: applicationCommand.id,
+          ...command.commandJSON
+        });
       } else if (deleteCommands) {
         this.emit('debug', `Removing command "${applicationCommand.name}" (${applicationCommand.id})`);
         await this.api.deleteCommand(applicationCommand.id);

--- a/src/creator.ts
+++ b/src/creator.ts
@@ -1,14 +1,7 @@
 import EventEmitter from 'eventemitter3';
 import Collection from '@discordjs/collection';
 import HTTPS from 'https';
-import {
-  formatAllowedMentions,
-  FormattedAllowedMentions,
-  MessageAllowedMentions,
-  objectKeySort,
-  oneLine,
-  verifyKey
-} from './util';
+import { formatAllowedMentions, FormattedAllowedMentions, MessageAllowedMentions, oneLine, verifyKey } from './util';
 import {
   ImageFormat,
   InteractionType,
@@ -383,33 +376,24 @@ class SlashCreator extends ((EventEmitter as any) as new () => TypedEmitter<Slas
           !!(command.guildIDs && command.guildIDs.includes(guildID) && command.commandName === partialCommand.name)
       );
       if (command) {
-        if (!isEqual(objectKeySort(partialCommand), objectKeySort(command.commandJSON))) {
-          this.emit(
-            'debug',
-            `Updating guild command "${applicationCommand.name}" (${applicationCommand.id}, guild: ${guildID})`
-          );
-        } else {
-          this.emit(
-            'debug',
-            `Guild command "${applicationCommand.name}" (${applicationCommand.id}) synced (guild: ${guildID})`
-          );
-        }
+        this.emit(
+          'debug',
+          `Found guild command "${applicationCommand.name}" (${applicationCommand.id}, guild: ${guildID})`
+        );
         updatePayload.push({
           id: applicationCommand.id,
           ...command.commandJSON
         });
         handledCommands.push(command.keyName);
       } else if (deleteCommands) {
-        // Command is removed
         this.emit(
           'debug',
           `Removing guild command "${applicationCommand.name}" (${applicationCommand.id}, guild: ${guildID})`
         );
-        await this.api.deleteCommand(applicationCommand.id, guildID);
+      } else {
+        updatePayload.push(applicationCommand);
       }
     }
-
-    if (updatePayload.length) await this.api.updateCommands(updatePayload, guildID);
 
     const unhandledCommands = this.commands.filter(
       (command) =>
@@ -418,8 +402,12 @@ class SlashCreator extends ((EventEmitter as any) as new () => TypedEmitter<Slas
 
     for (const [, command] of unhandledCommands) {
       this.emit('debug', `Creating guild command "${command.commandName}" (guild: ${guildID})`);
-      await this.api.createCommand(command.commandJSON, guildID);
+      updatePayload.push({
+        ...command.commandJSON
+      });
     }
+
+    if (updatePayload.length) await this.api.updateCommands(updatePayload, guildID);
   }
 
   /**
@@ -441,24 +429,19 @@ class SlashCreator extends ((EventEmitter as any) as new () => TypedEmitter<Slas
 
       const command = this.commands.get(commandKey);
       if (command) {
-        if (!isEqual(objectKeySort(partialCommand), objectKeySort(command.commandJSON))) {
-          this.emit('debug', `Updating command "${applicationCommand.name}" (${applicationCommand.id})`);
-        } else {
-          this.emit('debug', `Command "${applicationCommand.name}" (${applicationCommand.id}) synced`);
-        }
+        this.emit('debug', `Found command "${applicationCommand.name}" (${applicationCommand.id})`);
         updatePayload.push({
           id: applicationCommand.id,
           ...command.commandJSON
         });
       } else if (deleteCommands) {
         this.emit('debug', `Removing command "${applicationCommand.name}" (${applicationCommand.id})`);
-        await this.api.deleteCommand(applicationCommand.id);
+      } else {
+        updatePayload.push(applicationCommand);
       }
 
       handledCommands.push(commandKey);
     }
-
-    if (updatePayload.length) this.api.updateCommands(updatePayload);
 
     const unhandledCommands = this.commands.filter(
       (command) => !command.guildIDs && !handledCommands.includes(command.keyName)
@@ -466,8 +449,12 @@ class SlashCreator extends ((EventEmitter as any) as new () => TypedEmitter<Slas
 
     for (const [, command] of unhandledCommands) {
       this.emit('debug', `Creating command "${command.commandName}"`);
-      await this.api.createCommand(command.commandJSON);
+      updatePayload.push({
+        ...command.commandJSON
+      });
     }
+
+    if (updatePayload.length) this.api.updateCommands(updatePayload);
   }
 
   private _getCommandFromInteraction(interaction: InteractionRequestData) {

--- a/test/creator.ts
+++ b/test/creator.ts
@@ -12,16 +12,7 @@ import GatewayServer from '../src/servers/gateway';
 import GCFServer from '../src/servers/gcf';
 import { createBasicCommand } from './util/commands';
 import { basicCommands } from './util/constants';
-import {
-  deleteGlobalCommand,
-  deleteGuildCommand,
-  globalCommands,
-  guildCommands,
-  newGlobalCommand,
-  newGuildCommand,
-  updateGlobalCommands,
-  updateGuildCommands
-} from './util/nock';
+import { globalCommands, guildCommands, updateGlobalCommands, updateGuildCommands } from './util/nock';
 
 describe('SlashCreator', () => {
   describe('constructor', () => {
@@ -256,13 +247,6 @@ describe('SlashCreator', () => {
 
       const cmdsScope = globalCommands(basicCommands),
         guildCmdsScope = guildCommands([]),
-        postScope = newGuildCommand({
-          id: '0',
-          name: 'to-create-guild',
-          description: 'description',
-          application_id: '1',
-          version: '1'
-        }),
         putScope = updateGlobalCommands([
           {
             id: '1',
@@ -272,20 +256,26 @@ describe('SlashCreator', () => {
             version: '1'
           }
         ]),
-        deleteScope = deleteGlobalCommand('2');
+        putGuildScope = updateGuildCommands([
+          {
+            id: '1',
+            name: 'to-update',
+            description: 'description',
+            application_id: '1',
+            version: '1'
+          }
+        ]);
 
       creator.syncCommands();
       await expect(cmdsScope, 'requests commands').to.have.been.requested;
-      await expect(deleteScope, 'deletes old commands').to.have.been.requested;
       await expect(putScope, 'updates commands').to.have.been.requestedWith([
         { id: '1', name: 'to-update', description: 'description' },
         { id: '3', name: 'to-leave-alone', description: 'description' }
       ]);
       await expect(guildCmdsScope, 'requests guild commands').to.have.been.requested;
-      await expect(postScope, 'creates new guild commands').to.have.been.requestedWith({
-        name: 'to-create-guild',
-        description: 'description'
-      });
+      await expect(putGuildScope, 'updates guild commands').to.have.been.requestedWith([
+        { name: 'to-create-guild', description: 'description' }
+      ]);
     });
   });
 
@@ -302,14 +292,6 @@ describe('SlashCreator', () => {
         .registerCommand(createBasicCommand({ name: 'to-leave-alone', guildIDs: '123' }));
 
       const cmdsScope = guildCommands(basicCommands),
-        postScope = newGuildCommand({
-          id: '0',
-          name: 'to-create',
-          description: 'description',
-          guild_id: '123',
-          application_id: '1',
-          version: '1'
-        }),
         putScope = updateGuildCommands([
           {
             id: '1',
@@ -319,20 +301,15 @@ describe('SlashCreator', () => {
             application_id: '1',
             version: '1'
           }
-        ]),
-        deleteScope = deleteGuildCommand('2');
+        ]);
 
       const promise = expect(creator.syncCommandsIn('123')).to.be.fulfilled;
       await expect(cmdsScope, 'requests commands').to.have.been.requested;
-      await expect(deleteScope, 'deletes old commands').to.have.been.requested;
       await expect(putScope, 'updates commands').to.have.been.requestedWith([
         { id: '1', name: 'to-update', description: 'description' },
-        { id: '3', name: 'to-leave-alone', description: 'description' }
+        { id: '3', name: 'to-leave-alone', description: 'description' },
+        { name: 'to-create', description: 'description' }
       ]);
-      await expect(postScope, 'creates new commands').to.have.been.requestedWith({
-        name: 'to-create',
-        description: 'description'
-      });
       return promise;
     });
   });
@@ -350,13 +327,6 @@ describe('SlashCreator', () => {
         .registerCommand(createBasicCommand({ name: 'to-leave-alone' }));
 
       const cmdsScope = globalCommands(basicCommands),
-        postScope = newGlobalCommand({
-          id: '0',
-          name: 'to-create',
-          description: 'description',
-          application_id: '1',
-          version: '1'
-        }),
         putScope = updateGlobalCommands([
           {
             id: '1',
@@ -365,20 +335,15 @@ describe('SlashCreator', () => {
             application_id: '1',
             version: '1'
           }
-        ]),
-        deleteScope = deleteGlobalCommand('2');
+        ]);
 
       const promise = expect(creator.syncGlobalCommands()).to.be.fulfilled;
       await expect(cmdsScope, 'requests commands').to.have.been.requested;
-      await expect(deleteScope, 'deletes old commands').to.have.been.requested;
       await expect(putScope, 'updates commands').to.have.been.requestedWith([
         { id: '1', name: 'to-update', description: 'description' },
-        { id: '3', name: 'to-leave-alone', description: 'description' }
+        { id: '3', name: 'to-leave-alone', description: 'description' },
+        { name: 'to-create', description: 'description' }
       ]);
-      await expect(postScope, 'creates new commands').to.have.been.requestedWith({
-        name: 'to-create',
-        description: 'description'
-      });
       return promise;
     });
   });

--- a/test/creator.ts
+++ b/test/creator.ts
@@ -278,7 +278,8 @@ describe('SlashCreator', () => {
       await expect(cmdsScope, 'requests commands').to.have.been.requested;
       await expect(deleteScope, 'deletes old commands').to.have.been.requested;
       await expect(putScope, 'updates commands').to.have.been.requestedWith([
-        { id: '1', name: 'to-update', description: 'description' }
+        { id: '1', name: 'to-update', description: 'description' },
+        { id: '3', name: 'to-leave-alone', description: 'description' }
       ]);
       await expect(guildCmdsScope, 'requests guild commands').to.have.been.requested;
       await expect(postScope, 'creates new guild commands').to.have.been.requestedWith({
@@ -325,11 +326,8 @@ describe('SlashCreator', () => {
       await expect(cmdsScope, 'requests commands').to.have.been.requested;
       await expect(deleteScope, 'deletes old commands').to.have.been.requested;
       await expect(putScope, 'updates commands').to.have.been.requestedWith([
-        {
-          id: '1',
-          name: 'to-update',
-          description: 'description'
-        }
+        { id: '1', name: 'to-update', description: 'description' },
+        { id: '3', name: 'to-leave-alone', description: 'description' }
       ]);
       await expect(postScope, 'creates new commands').to.have.been.requestedWith({
         name: 'to-create',
@@ -374,11 +372,8 @@ describe('SlashCreator', () => {
       await expect(cmdsScope, 'requests commands').to.have.been.requested;
       await expect(deleteScope, 'deletes old commands').to.have.been.requested;
       await expect(putScope, 'updates commands').to.have.been.requestedWith([
-        {
-          id: '1',
-          name: 'to-update',
-          description: 'description'
-        }
+        { id: '1', name: 'to-update', description: 'description' },
+        { id: '3', name: 'to-leave-alone', description: 'description' }
       ]);
       await expect(postScope, 'creates new commands').to.have.been.requestedWith({
         name: 'to-create',


### PR DESCRIPTION
This fixes a situation where one command out of many is updated and caused the other commands to disappear from Discord.

The root cause was that only the updated command is sent with a `PUT` requests and overwrites the commands resource completely, different from what a `PATCH` request does (modifies a resource).

https://en.wikipedia.org/wiki/Patch_verb#:~:text=The%20main%20difference%20between%20the,instructions%20to%20modify%20the%20resource.