### PR TITLE
feat: Send attachments

### DIFF
--- a/docs/general/faq.md
+++ b/docs/general/faq.md
@@ -1,0 +1,69 @@
+# FAQ
+
+## Terminology
+
+### What are **initial messages**?
+Any first response sent out during the "Sending command..." message. The initial response can be a plain message or a deferred message.
+
+### What is a **deferred message**?
+A deferred message is an acknowlegement that the message will soon be edited later on. A deferred message has been sent if the response is the "Bot is thinking..." message.
+
+## Common Problems
+
+### `ts-node` can't load commands from folders!
+`ts-node` only compiles other TypeScript files that are imported directly and because of this, no other files are compiled and therefore not recognized. You will need to use `tsc` in order to compile everything or try [ts-devscript](https://npm.im/ts-devscript) for development environments.
+
+### My attachments aren't showing!
+Attachments cannot be sent within **ephemeral messages** and **initial messages**. You should also make sure that the files are sending **buffers**.
+
+```js
+ctx.send({
+  content: 'hello',
+  file: {
+    name: 'avatar.png',
+    file: fs.readFileSync('avatar.png')
+  }
+});
+```
+
+## External Libraries
+
+### How can I get the client from my slash command?
+slash-create does not support passing a client through the command context, since the library is also used for webservers.
+```js
+// bot.js
+const Discord = require('discord.js');
+const { SlashCreator, GatewayServer } = require('slash-create');
+
+const client = new Discord.Client(/* ... */);
+// ...
+
+module.exports = client;
+```
+```js
+// commands/command.js
+const { SlashCommand, CommandOptionType } = require('slash-create');
+const client = require("../bot.js");
+
+module.exports = class HelloCommand extends SlashCommand {
+  // ...
+  async run(ctx) {
+    // do stuff with the client...
+  }
+}
+```
+
+### MessageEmbed doesn't work with this!
+slash-create doesn't support `discord.js`'s MessageEmbed out of the box.
+You can still use the builder if you send an embed JSON.
+```js
+const embed = new Discord.MessageEmbed()
+  .setTitle('Hi')
+  .setColor('RANDOM')
+  .setTimestamp()
+  .setDescription('Hello');
+
+ctx.send([
+  embeds: [embed.toJSON()]
+])
+```

--- a/docs/index.yml
+++ b/docs/index.yml
@@ -2,6 +2,8 @@
   files:
     - name: Welcome
       path: welcome.md
+    - name: FAQ
+      path: faq.md
     - name: Changelog
       path: changelog.md
     - name: CommandContext.options

--- a/src/command.ts
+++ b/src/command.ts
@@ -143,7 +143,7 @@ class SlashCommand {
    * - permission: `response` ({@link string}) to send
    * - throttling: `throttle` ({@link Object}), `remaining` ({@link number}) time in seconds
    */
-  onBlock(ctx: CommandContext, reason: string, data?: any) {
+  onBlock(ctx: CommandContext, reason: string, data?: any): any {
     switch (reason) {
       case 'permission': {
         if (data.response) return ctx.send(data.response, { ephemeral: true });
@@ -165,7 +165,7 @@ class SlashCommand {
    * @param err Error that was thrown
    * @param ctx Command context the command is running from
    */
-  onError(err: Error, ctx: CommandContext) {
+  onError(err: Error, ctx: CommandContext): any {
     if (!ctx.expired && !ctx.initiallyResponded)
       return ctx.send('An error occurred while running the command.', { ephemeral: true });
   }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -187,7 +187,7 @@ export interface GuildInteractionRequestData {
 export type InteractionRequestData = DMInteractionRequestData | GuildInteractionRequestData;
 
 /** @private */
-export interface ResolvedMember {
+export interface ResolvedMemberData {
   roles: string[];
   premium_since: string | null;
   pending: boolean;
@@ -197,7 +197,7 @@ export interface ResolvedMember {
 }
 
 /** @private */
-export interface CommandMember extends ResolvedMember {
+export interface CommandMember extends ResolvedMemberData {
   user: CommandUser;
   mute: boolean;
   deaf: boolean;
@@ -246,7 +246,7 @@ export interface CommandData {
   options?: AnyCommandOption[];
   resolved?: {
     users?: { [id: string]: CommandUser };
-    members?: { [id: string]: ResolvedMember };
+    members?: { [id: string]: ResolvedMemberData };
     roles?: { [id: string]: ResolvedRole };
     channels?: { [id: string]: ResolvedChannel };
   };

--- a/src/context.ts
+++ b/src/context.ts
@@ -27,10 +27,24 @@ export interface EditMessageOptions {
   embeds?: any[];
   /** The mentions allowed to be used in this message. */
   allowedMentions?: MessageAllowedMentions;
+  /**
+   * The attachment(s) to send with the message.
+   * Note that ephemeral messages and initial messages cannot have
+   * attachments.
+   */
+  file?: MessageFile | MessageFile[];
+}
+
+/** A file within {@link EditMessageOptions}. */
+export interface MessageFile {
+  /** The attachment to send. */
+  file: Buffer;
+  /** The name of the file. */
+  name: string;
 }
 
 /** The options for {@link CommandContext#sendFollowUp}. */
-interface FollowUpMessageOptions extends EditMessageOptions {
+export interface FollowUpMessageOptions extends EditMessageOptions {
   /** Whether to use TTS for the content. */
   tts?: boolean;
   /** The flags to use in the message. */
@@ -236,7 +250,8 @@ class CommandContext {
         content: options.content,
         embeds: options.embeds,
         allowed_mentions: allowedMentions
-      }
+      },
+      options.file
     );
     return new Message(data, this);
   }
@@ -272,7 +287,8 @@ class CommandContext {
         content: options.content,
         embeds: options.embeds,
         allowed_mentions: allowedMentions
-      }
+      },
+      options.file
     );
     return new Message(data, this);
   }

--- a/src/structures/resolvedMember.ts
+++ b/src/structures/resolvedMember.ts
@@ -1,4 +1,4 @@
-import { CommandUser, ResolvedMember as ResolvedMemberData } from '../constants';
+import { CommandUser, ResolvedMemberData } from '../constants';
 import SlashCreator from '../creator';
 import User from './user';
 

--- a/src/util/multipartData.ts
+++ b/src/util/multipartData.ts
@@ -1,0 +1,29 @@
+class MultipartData {
+  boundary = '----------------SlashCreate';
+  bufs: Buffer[] = [];
+
+  attach(fieldName: string, data: any, filename?: string) {
+    if (data === undefined) {
+      return;
+    }
+    let str = '\r\n--' + this.boundary + '\r\nContent-Disposition: form-data; name="' + fieldName + '"';
+    if (filename) str += '; filename="' + filename + '"';
+    if (data instanceof Buffer) {
+      str += '\r\nContent-Type: application/octet-stream';
+    } else if (typeof data === 'object') {
+      str += '\r\nContent-Type: application/json';
+      data = Buffer.from(JSON.stringify(data));
+    } else {
+      data = Buffer.from('' + data);
+    }
+    this.bufs.push(Buffer.from(str + '\r\n\r\n'));
+    this.bufs.push(data);
+  }
+
+  finish() {
+    this.bufs.push(Buffer.from('\r\n--' + this.boundary + '--'));
+    return this.bufs;
+  }
+}
+
+export default MultipartData;


### PR DESCRIPTION
closes #31 

This allows attachments to be sent within messages. Note that attachments will not appear in **ephemeral messages** or **initial messages**.
```js
ctx.send({
  content: 'hello',
  file: [
    {
      name: 'a.txt',
      file: Buffer.from('b')
    },
    {
      name: 'b.txt',
      file: Buffer.from('c')
    }
  ]
});
```
```js
ctx.send({
  content: 'hello',
  file: {
    name: 'a.txt',
    file: Buffer.from('b')
  }
});
```