### PR TITLE
Allow empty payloads when syncing commands

### DIFF
--- a/src/creator.ts
+++ b/src/creator.ts
@@ -451,7 +451,7 @@ class SlashCreator extends ((EventEmitter as any) as new () => TypedEmitter<Slas
       });
     }
 
-    if (updatePayload.length) this.api.updateCommands(updatePayload);
+    this.api.updateCommands(updatePayload);
   }
 
   private _getCommandFromInteraction(interaction: InteractionRequestData) {

--- a/src/creator.ts
+++ b/src/creator.ts
@@ -404,7 +404,7 @@ class SlashCreator extends ((EventEmitter as any) as new () => TypedEmitter<Slas
       });
     }
 
-    if (updatePayload.length) await this.api.updateCommands(updatePayload, guildID);
+    await this.api.updateCommands(updatePayload, guildID);
   }
 
   /**


### PR DESCRIPTION
Before this PR, the `syncCommands` method would delete commands if `deleteCommands` is set to true, but only if the creator has at least one other command registered. This is because the method wouldn't send an empty payload.

This PR removes the empty payload check in `syncCommandsIn` and `syncCommandsGlobal` so it is allowed to be sent. An empty payload sent to the commands endpoint will delete all commands, as expected.

Guild commands still will not be deleted with `syncCommands` because the library has no way of knowing what guild commands exist without them being defined locally. But the user can still call `syncCommandsIn` directly with their guild ID(s) to delete all guild commands.