### PR TITLE
Delay CommandContext.editOriginal() for bot clients too

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -295,15 +295,14 @@ class CommandContext {
 
   /**
    * Edits the original message.
-   * This is put on a timeout of 150 ms for webservers to account for
-   * Discord recieving and processing the original response.
+   * This is put on a timeout of 150 ms to account for
+   * Discord receiving and processing the original response.
    * Note: This will error with ephemeral messages or deferred ephemeral messages.
    * @param content The content of the message
    * @param options The message options
    */
   editOriginal(content: string | EditMessageOptions, options?: EditMessageOptions): Promise<Message> {
     this.deferred = false;
-    if (!this.webserverMode) return this.edit('@original', content, options);
     return new Promise((resolve, reject) =>
       setTimeout(() => this.edit('@original', content, options).then(resolve).catch(reject), 150)
     );


### PR DESCRIPTION
The method `ctx.editOriginal()` includes a 150ms delay when in webserver mode. This delay seems to be necessary when using bot clients as well, since you can cause Discord to respond with `Unknown Message` even when using a bot client just by sending a message too quickly after a defer, or calling `editOriginal()` too quickly after the original message was sent.

```ts
// Using a bot client, not a webserver (Eris and Discord.js were tested)
async run(ctx) {
  ctx.defer();
  ctx.send('test'); // Will almost always cause a 404
}
```

Calling defer with `await` is an easy way to avoid the error, but the library should be responsible for avoiding an error like this.

This PR changes the method so the delay is used in either mode.