### PR TITLE
fix square brackets and embed warning (docs)

### DIFF
--- a/docs/general/faq.md
+++ b/docs/general/faq.md
@@ -84,18 +84,34 @@ module.exports = class HelloCommand extends SlashCommand {
 }
 ```
 
-### How can i send an embed?
-You can create a embed using `discord.js`'s MessageEmbed, here is an example!
+### MessageEmbed files don't work with this!
+slash-create doesn't support `discord.js`'s MessageEmbed out of the box.
+You can still use the builder as such, however any files attached to the builder will not be handled and should be included in the message options instead.
 ```js
-const exampleEmbed = new Discord.MessageEmbed()
+// Regular embed
+const embed = new Discord.MessageEmbed()
   .setTitle('Hi')
   .setColor('RANDOM')
   .setTimestamp()
   .setDescription('Hello');
 
-ctx.send({
-  embeds: [exampleEmbed]
-})
+ctx.send([
+  embeds: [embed]
+])
+```
+```js
+// Embed with files
+const embed = new Discord.MessageEmbed()
+  .setTitle('Look at this image')
+  .setImage('attachment://coolimage.png');
+
+ctx.send([
+  embeds: [embed],
+  file: {
+    name: 'coolimage.png',
+    file: fs.readFileSync('coolimage.png')
+  }
+])
 ```
 
 ### My bot sent a message but it's still thinking.

--- a/docs/general/faq.md
+++ b/docs/general/faq.md
@@ -84,6 +84,20 @@ module.exports = class HelloCommand extends SlashCommand {
 }
 ```
 
+### How can i send an embed?
+You can create a embed using `discord.js`'s MessageEmbed, here is an example!
+```js
+const exampleEmbed = new Discord.MessageEmbed()
+  .setTitle('Hi')
+  .setColor('RANDOM')
+  .setTimestamp()
+  .setDescription('Hello');
+
+ctx.send({
+  embeds: [exampleEmbed]
+})
+```
+
 ### My bot sent a message but it's still thinking.
 Make sure that you have updated `slash-create` to the latest version. There is a pretty good chance you are **creating the message outside of the interaction**, which does not show that the interaction has been completed. (by editing the deferred message or using `ctx.send`)
 

--- a/docs/general/faq.md
+++ b/docs/general/faq.md
@@ -84,21 +84,6 @@ module.exports = class HelloCommand extends SlashCommand {
 }
 ```
 
-### MessageEmbed doesn't work with this!
-slash-create doesn't support `discord.js`'s MessageEmbed out of the box.
-You can still use the builder if you send an embed JSON.
-```js
-const embed = new Discord.MessageEmbed()
-  .setTitle('Hi')
-  .setColor('RANDOM')
-  .setTimestamp()
-  .setDescription('Hello');
-
-ctx.send([
-  embeds: [embed.toJSON()]
-])
-```
-
 ### My bot sent a message but it's still thinking.
 Make sure that you have updated `slash-create` to the latest version. There is a pretty good chance you are **creating the message outside of the interaction**, which does not show that the interaction has been completed. (by editing the deferred message or using `ctx.send`)
 


### PR DESCRIPTION
since it works sending an regular Embed or Embed (MessageEmbed) without using ".toJSON()", this warning should be edited.