### PR TITLE
Adjust ComponentContext docs URL

### DIFF
--- a/docs/examples/components.md
+++ b/docs/examples/components.md
@@ -1,4 +1,4 @@
-View the [documentation for Component Contexts](https://slash-create.js.org/#/docs/main/$$$ref/class/ComponentContext) to know what to use.
+View the [documentation for Component Contexts](https://slash-create.js.org/#/docs/main/master/class/ComponentContext) to know what to use.
 
 ### Basic Event Usage
 ```js


### PR DESCRIPTION
The URL for the ComponentContext documentation on the `Examples - Message Component` page is incorrect and does not lead to any documentation. This changes the URL to point to the ComponentContext documentation on the Master branch.