### PR TITLE
419 Rate limit reached - JSON Parse error

### DIFF
--- a/src/util/requestHandler.ts
+++ b/src/util/requestHandler.ts
@@ -329,7 +329,6 @@ class RequestHandler {
                   // For some reason, the Retry-After header isn't in ms precision
                   // This should hopefully fix any spam requests
                   if (response) {
-                    response = JSON.parse(response);
                     if (response.retry_after) retryAfter = response.retry_after * 1000 + 250;
                   }
                   if (retryAfter) {


### PR DESCRIPTION
This fixes the rate limit error with a JSON parse error. I was getting the following error:
![P3bZ5](https://user-images.githubusercontent.com/14042234/120071387-61e22900-c08f-11eb-886f-396c72a183f7.png)

This should fix the error and stop rebooting the application if you are using PM2.