### PR TITLE
feat: Select Menu Component

### DIFF
--- a/docs/examples/components.md
+++ b/docs/examples/components.md
@@ -30,7 +30,6 @@ creator.on('componentInteraction', async ctx => {
 })
 ```
 
-
 ### Usage in commands
 ```js
 const { SlashCommand, ComponentType, ButtonStyle } = require('slash-create');
@@ -68,6 +67,76 @@ module.exports = class ButtonCommand extends SlashCommand {
      */
     ctx.registerComponent('example_button', async (btnCtx) => {
       await btnCtx.editParent('You clicked the button!');
+    });
+  }
+}
+```
+
+### Select Component Example
+Note: Only one Select component is allowed per action row. ([See Documentation](https://discord.com/developers/docs/interactions/message-components#select-menus))
+```js
+const { SlashCommand, ComponentType } = require('slash-create');
+
+module.exports = class ButtonCommand extends SlashCommand {
+  constructor(creator) {
+    super(creator, {
+      name: 'class',
+      description: 'Select a class!'
+    });
+
+    this.filePath = __filename;
+  }
+
+  async run(ctx) {
+    await ctx.defer();
+    await ctx.send('What class do you want?', {
+      components: [{
+        type: ComponentType.ACTION_ROW,
+        components: [{
+          type: ComponentType.SELECT,
+          custom_id: 'class_select',
+          placeholder: "Choose a class",
+          min_values: 1,
+          max_values: 3,
+          options: [
+              {
+                  label: "Rogue",
+                  value: "rogue",
+                  description: "Sneak 'n stab",
+                  emoji: {
+                      name: "rogue",
+                      id: "625891304148303894"
+                  }
+              },
+              {
+                  label: "Mage",
+                  value: "mage",
+                  description: "Turn 'em into a sheep",
+                  emoji: {
+                      "name": "mage",
+                      "id": "625891304081063986"
+                  }
+              },
+              {
+                  label: "Priest",
+                  value: "priest",
+                  description: "You get heals when I'm done doing damage",
+                  emoji: {
+                      "name": "priest",
+                      "id": "625891303795982337"
+                  }
+              }
+          ]
+        }]
+      }]
+    });
+
+    /**
+     * This function handles component contexts within a command, so you
+     * can use the previous context aswell.
+     */
+    ctx.registerComponent('class_select', async (selectCtx) => {
+      await selectCtx.editParent('You selected the following classes: ' + selectCtx.values.join(', '));
     });
   }
 }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -286,6 +286,7 @@ export interface DMMessageComponentRequestData {
   data: {
     custom_id: string;
     component_type: ComponentType;
+    values?: string[];
   };
 }
 
@@ -435,7 +436,9 @@ export enum ComponentType {
   /** A row of components. */
   ACTION_ROW = 1,
   /** A button component. */
-  BUTTON = 2
+  BUTTON = 2,
+  /** A select component. */
+  SELECT = 3
 }
 
 /** The types of component button styles. */
@@ -453,14 +456,14 @@ export enum ButtonStyle {
 }
 
 /** Any component. */
-export type AnyComponent = ComponentActionRow | AnyComponentButton;
+export type AnyComponent = ComponentActionRow | AnyComponentButton | ComponentSelectMenu;
 
 /** A row of components. */
 export interface ComponentActionRow {
   /** The type of component to use. */
   type: ComponentType.ACTION_ROW;
   /** The components to show inside this row. */
-  components: AnyComponentButton[];
+  components: AnyComponentButton[] | [ComponentSelectMenu];
 }
 
 /** Any component button. */
@@ -488,6 +491,33 @@ export interface ComponentButtonLink extends Omit<ComponentButton, 'custom_id' |
   style: ButtonStyle.LINK;
   /** The URL for link buttons. */
   url: string;
+}
+
+export interface ComponentSelectMenu {
+  /** The type of component to use. */
+  type: ComponentType.SELECT;
+  /** The identifier of the of the menu. */
+  custom_id: string;
+  /** The options to show inside this menu. */
+  options: ComponentSelectOption[];
+  /** The string to show in absence of a selected option. */
+  placeholder?: string;
+  /** The minimum number of items to be chosen. */
+  min_values?: number;
+  /** The maximum number of items to be chosen. */
+  max_values?: number;
+}
+
+export interface ComponentSelectOption {
+  description: string;
+  /** The emoji to show with the option. */
+  emoji?: PartialEmoji;
+  /** The label of this option. */
+  label: string;
+  /** The value of this option. */
+  value: string;
+  /** Should this render by default */
+  default?: boolean;
 }
 
 /** @see https://www.npmjs.com/package/require-all#usage */

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -306,6 +306,7 @@ export interface GuildMessageComponentRequestData {
   data: {
     custom_id: string;
     component_type: ComponentType;
+    values?: string[];
   };
 }
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -464,7 +464,7 @@ export interface ComponentActionRow {
   /** The type of component to use. */
   type: ComponentType.ACTION_ROW;
   /** The components to show inside this row. */
-  components: AnyComponentButton[] | [ComponentSelectMenu];
+  components: (AnyComponentButton | ComponentSelectMenu)[];
 }
 
 /** Any component button. */

--- a/src/index.ts
+++ b/src/index.ts
@@ -71,6 +71,8 @@ export {
   AnyComponentButton,
   ComponentButton,
   ComponentButtonLink,
+  ComponentSelectMenu,
+  ComponentSelectOption,
   PartialEmoji,
   PartialMessage,
   ImageFormat

--- a/src/structures/interfaces/componentContext.ts
+++ b/src/structures/interfaces/componentContext.ts
@@ -14,6 +14,8 @@ class ComponentContext extends MessageInteractionContext {
   readonly customID: string;
   /** The type of component this interaction came from. */
   readonly componentType: ComponentType;
+  /** The the values of the interaction, if the component was a SELECT. */
+  readonly values: string[];
   /** The partial message this interaction came from. */
   readonly message: PartialMessage;
 
@@ -31,6 +33,7 @@ class ComponentContext extends MessageInteractionContext {
 
     this.customID = data.data.custom_id;
     this.componentType = data.data.component_type;
+    this.values = data.data.values || [];
     this.message = data.message;
 
     // Auto-acknowledge if no response was given in 2 seconds

--- a/test/__util__/constants.ts
+++ b/test/__util__/constants.ts
@@ -106,6 +106,15 @@ export const basicMessageInteraction: MessageComponentRequestData = {
   }
 };
 
+export const selectMessageInteraction: MessageComponentRequestData = {
+  ...basicMessageInteraction,
+  data: {
+    custom_id: '0',
+    component_type: ComponentType.SELECT,
+    values: ['1', '2']
+  }
+};
+
 export const subCommandInteraction: InteractionRequestData = {
   ...interactionDefaults,
   data: {

--- a/test/structures/interfaces/componentContext.ts
+++ b/test/structures/interfaces/componentContext.ts
@@ -7,7 +7,13 @@ import 'mocha';
 const expect = chai.expect;
 import FakeTimers from '@sinonjs/fake-timers';
 
-import { creator, noop, basicMessageInteraction, followUpMessage } from '../../__util__/constants';
+import {
+  creator,
+  noop,
+  basicMessageInteraction,
+  followUpMessage,
+  selectMessageInteraction
+} from '../../__util__/constants';
 import ComponentContext from '../../../src/structures/interfaces/componentContext';
 import { InteractionResponseType } from '../../../src/constants';
 import { editMessage } from '../../__util__/nock';
@@ -39,6 +45,16 @@ describe('ComponentContext', () => {
       expect(ctx.message).to.equal(basicMessageInteraction.message);
       expect(ctx.customID).to.equal(basicMessageInteraction.data.custom_id);
       expect(ctx.componentType).to.equal(basicMessageInteraction.data.component_type);
+    });
+
+    it('assigns properties properly for select interactions', async () => {
+      const ctx = new ComponentContext(creator, selectMessageInteraction, noop);
+      await ctx.acknowledge();
+
+      expect(ctx.message).to.equal(selectMessageInteraction.message);
+      expect(ctx.customID).to.equal(selectMessageInteraction.data.custom_id);
+      expect(ctx.componentType).to.equal(selectMessageInteraction.data.component_type);
+      expect(ctx.values).to.equal(selectMessageInteraction.data.values);
     });
   });
 


### PR DESCRIPTION
[Select Menu Component Documentation](https://discord.com/developers/docs/interactions/message-components#select-menus)

- [x] Types
- [x] Context
- [x] Tests
- [x] Documentation
- [x] Additional
  - [x] `DMMessageComponentRequestData` changes to reflect on `GuildMessageComponentRequestData`

`ComponentActionRow#components` has been modified as per the spec of this component, which states:
> - An Action Row can only contain one select menu
> - An Action Row containing a select menu cannot also contain buttons

That said, I would expect changes to be suggested on this if this is considered as conflicting behaviour.

## Changelog

### Added

- Types `ComponentSelectMenu` and `ComponentSelectOption` are exported to the index
- `ComponentActionRow` now accepts `ComponentSelectMenu`
- Added `SELECT` to enum `ComponentType`
- Added `ComponentSelectMenu` as a component alternative of `AnyComponent`
- Added `values` property to `ComponentContext`