### PR TITLE
fix(types): make ComponentSelectOption.description optional

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -510,7 +510,8 @@ export interface ComponentSelectMenu {
 }
 
 export interface ComponentSelectOption {
-  description: string;
+  /** The description of this option. */
+  description?: string;
   /** The emoji to show with the option. */
   emoji?: PartialEmoji;
   /** The label of this option. */


### PR DESCRIPTION
A tiny change to make the description property in ComponentSelectOption optional.
The [API docs](https://discord.com/developers/docs/interactions/message-components#select-menu-object-select-option-structure) mention that it is optional, and I have been excluding it with `/** @ts-ignore */` just fine.