### PR TITLE
patch(MessageInteraction): remove message reference on delete

### DIFF
--- a/src/structures/interfaces/messageInteraction.ts
+++ b/src/structures/interfaces/messageInteraction.ts
@@ -219,13 +219,13 @@ export class MessageInteractionContext {
   async delete(messageID?: string) {
     if (this.expired) throw new Error('This interaction has expired');
 
-    return this.creator.requestHandler.request(
+    const res = await this.creator.requestHandler.request(
       'DELETE',
       Endpoints.MESSAGE(this.creator.options.applicationID, this.interactionToken, messageID)
-    ).then(res => {
-      if(!messageID && messageID === '@original') this.messageID = undefined;
-      return res;
-    });
+    );
+    
+    if(!messageID || messageID === '@original') this.messageID = undefined;
+    return res;
   }
 
   /**

--- a/src/structures/interfaces/messageInteraction.ts
+++ b/src/structures/interfaces/messageInteraction.ts
@@ -222,7 +222,10 @@ export class MessageInteractionContext {
     return this.creator.requestHandler.request(
       'DELETE',
       Endpoints.MESSAGE(this.creator.options.applicationID, this.interactionToken, messageID)
-    );
+    ).then(res => {
+      if(!messageID && messageID === '@original') this.messageID = undefined;
+      return res;
+    });
   }
 
   /**

--- a/src/structures/interfaces/messageInteraction.ts
+++ b/src/structures/interfaces/messageInteraction.ts
@@ -223,8 +223,8 @@ export class MessageInteractionContext {
       'DELETE',
       Endpoints.MESSAGE(this.creator.options.applicationID, this.interactionToken, messageID)
     );
-    
-    if(!messageID || messageID === '@original') this.messageID = undefined;
+
+    if (!messageID || messageID === '@original') this.messageID = undefined;
     return res;
   }
 


### PR DESCRIPTION
## Patched

- Ensure `@original` message ref is set as `undefined` when calling `MessageInteractionContext#delete()`.