### PR TITLE
feat: Add Vercel Serverless Hosting Support

### DIFF
--- a/docs/examples/vercel.md
+++ b/docs/examples/vercel.md
@@ -1,0 +1,52 @@
+**➡️ Please note that a working templatereference can be found [here](https://github.com/GabrielTK/VercelSlashCreate).**
+
+The most important thing is to:
+1. Export the VercelServer instance:
+```ts
+const { VercelServer } = require('slash-create');
+const vercelServer = new VercelServer();
+creator
+  .withServer(vercelServer)
+  .registerCommandsIn(path.join(__dirname, 'commands'))
+  //.syncCommands()
+
+export const vercel = vercelServer;
+export const slash = creator;
+```
+2. Then, create a directory called `api`, with the two following files:
+
+* `interactions.ts`
+```ts
+import { vercel } from ".."; //This is the VercelServer we exported from the previous step.
+
+
+export default vercel.vercelEndpoint;
+```
+
+* `resync.ts` - This file can be renamed, and will be used to resync the interactions with Discord API. I recommend you use this as a post-deploy hook.
+
+```ts
+import { VercelRequest, VercelResponse } from "@vercel/node";
+import { slash } from "..";
+
+const api = async (req: VercelRequest, res: VercelResponse) => {
+  //I do recommend you add secret verification here, or some security check.
+  slash.syncCommands();
+  //This basically waits until the sync is done
+  let awaiter = new Promise((resolve,reject) => {
+  slash.on('synced', () => {
+    console.log("Elapsed Sync")
+   resolve(true);
+  });
+  });
+  slash.syncCommands();
+  await awaiter;
+  res.status(200).send(JSON.stringify(slash.commands.map(c => [{name: c.commandName, description: c.description}])));
+}
+export default api;
+```
+
+Now, just push it to Vercel! Be sure to verify that the source files are not exposed, and that `/api/interactions` results in a response such as `Server only supports POST requests.` - That's the URL you'll use as your `INTERACTIONS ENDPOINT URL` on your [Discord Developers Page](https://discord.com/developers/)
+
+
+

--- a/docs/index.yml
+++ b/docs/index.yml
@@ -30,3 +30,5 @@
       path: lambda.md
     - name: Azure Functions
       path: azure.md
+    - name: Vercel
+      path: vercel.md

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "chai-nock": "^1.3.0",
     "eslint": "^7.32.0",
     "eslint-config-prettier": "^8.3.0",
-    "eslint-plugin-prettier": "^3.4.0",
+    "eslint-plugin-prettier": "^4.0.0",
     "fastify": "^3.20.1",
     "husky": "^7.0.1",
     "lint-staged": "^11.1.2",

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "@types/sinonjs__fake-timers": "6.0.1",
     "@typescript-eslint/eslint-plugin": "^4.29.1",
     "@typescript-eslint/parser": "^4.29.1",
+    "@vercel/node": "^1.12.1",
     "chai": "^4.3.4",
     "chai-as-promised": "^7.1.1",
     "chai-nock": "^1.3.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,7 @@ export * from './servers/express';
 export * from './servers/fastify';
 export * from './servers/gateway';
 export * from './servers/gcf';
+export * from './servers/vercel';
 
 export * from './structures/member';
 export * from './structures/message';

--- a/yarn.lock
+++ b/yarn.lock
@@ -184,6 +184,11 @@
   resolved "https://registry.yarnpkg.com/@types/mocha/-/mocha-9.0.0.tgz#3205bcd15ada9bc681ac20bef64e9e6df88fd297"
   integrity sha512-scN0hAWyLVAvLR9AyW7HoFF5sJZglyBsbPuHO4fv7JRvfmPBMfp1ozWqOf/e4wwPNxezBZXRfWzMb6iFLgEVRA==
 
+"@types/node@*":
+  version "16.7.13"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.7.13.tgz#86fae356b03b5a12f2506c6cf6cd9287b205973f"
+  integrity sha512-pLUPDn+YG3FYEt/pHI74HmnJOWzeR+tOIQzUx93pi9M7D8OE7PSLr97HboXwk5F+JS+TLtWuzCOW97AHjmOXXA==
+
 "@types/node@^16.4.14":
   version "16.7.10"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-16.7.10.tgz#7aa732cc47341c12a16b7d562f519c2383b6d4fc"
@@ -289,6 +294,15 @@
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz#aa58042711d6e3275dd37dc597e5d31e8c290a44"
   integrity sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==
+
+"@vercel/node@^1.12.1":
+  version "1.12.1"
+  resolved "https://registry.yarnpkg.com/@vercel/node/-/node-1.12.1.tgz#15f42f64690f904f8a52a387123ce0958657060f"
+  integrity sha512-NcawIY05BvVkWlsowaxF2hl/hJg475U8JvT2FnGykFPMx31q1/FtqyTw/awSrKfOSRXR0InrbEIDIelmS9NzPA==
+  dependencies:
+    "@types/node" "*"
+    ts-node "8.9.1"
+    typescript "4.3.4"
 
 abstract-logging@^2.0.0:
   version "2.0.1"
@@ -473,6 +487,11 @@ browser-stdout@1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/browser-stdout/-/browser-stdout-1.3.1.tgz#baa559ee14ced73452229bad7326467c61fabd60"
   integrity sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==
+
+buffer-from@^1.0.0:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.2.tgz#2b146a6fd72e80b4f55d255f35ed59a3a9a41bd5"
+  integrity sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==
 
 call-bind@^1.0.2:
   version "1.0.2"
@@ -2143,7 +2162,15 @@ sonic-boom@^1.0.2:
     atomic-sleep "^1.0.0"
     flatstr "^1.0.12"
 
-source-map@^0.6.1:
+source-map-support@^0.5.17:
+  version "0.5.19"
+  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.19.tgz#a98b62f86dcaf4f67399648c085291ab9e8fed61"
+  integrity sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==
+  dependencies:
+    buffer-from "^1.0.0"
+    source-map "^0.6.0"
+
+source-map@^0.6.0, source-map@^0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
@@ -2292,6 +2319,17 @@ to-regex-range@^5.0.1:
     typedoc "^0.20.29"
     typedoc-plugin-as-member-of "^1.0.2"
 
+ts-node@8.9.1:
+  version "8.9.1"
+  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-8.9.1.tgz#2f857f46c47e91dcd28a14e052482eb14cfd65a5"
+  integrity sha512-yrq6ODsxEFTLz0R3BX2myf0WBCSQh9A+py8PBo1dCzWIOcvisbyH6akNKqDHMgXePF2kir5mm5JXJTH3OUJYOQ==
+  dependencies:
+    arg "^4.1.0"
+    diff "^4.0.1"
+    make-error "^1.1.1"
+    source-map-support "^0.5.17"
+    yn "3.1.1"
+
 ts-node@^10.2.0:
   version "10.2.1"
   resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-10.2.1.tgz#4cc93bea0a7aba2179497e65bb08ddfc198b3ab5"
@@ -2397,6 +2435,11 @@ typedoc@^0.20.29:
     shelljs "^0.8.4"
     shiki "^0.9.3"
     typedoc-default-themes "^0.12.10"
+
+typescript@4.3.4:
+  version "4.3.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.3.4.tgz#3f85b986945bcf31071decdd96cf8bfa65f9dcbc"
+  integrity sha512-uauPG7XZn9F/mo+7MrsRjyvbxFpzemRjKEZXS4AK83oP2KKOJPvb+9cO/gmnv8arWZvhnjVOXz7B49m1l0e9Ew==
 
 typescript@4.3.5:
   version "4.3.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -777,10 +777,10 @@ eslint-config-prettier@^8.3.0:
   resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-8.3.0.tgz#f7471b20b6fe8a9a9254cc684454202886a2dd7a"
   integrity sha512-BgZuLUSeKzvlL/VUjx/Yb787VQ26RU3gGjA3iiFvdsp/2bMfVIWUVP7tjxtjS0e+HP409cPlPvNkQloz8C91ew==
 
-eslint-plugin-prettier@^3.4.0:
-  version "3.4.1"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-3.4.1.tgz#e9ddb200efb6f3d05ffe83b1665a716af4a387e5"
-  integrity sha512-htg25EUYUeIhKHXjOinK4BgCcDwtLHjqaxCDsMy5nbnUMkKFvIhMVCp+5GFUXQ4Nr8lBsPqtGAqBenbpFqAA2g==
+eslint-plugin-prettier@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-4.0.0.tgz#8b99d1e4b8b24a762472b4567992023619cb98e0"
+  integrity sha512-98MqmCJ7vJodoQK359bqQWaxOE0CS8paAz/GgjaZLyex4TTk3g9HugoO89EqWCrFiOqn9EVvcoo7gZzONCWVwQ==
   dependencies:
     prettier-linter-helpers "^1.0.0"
 


### PR DESCRIPTION
This adds a `VercelServer` class, which allows the bot to be hosted on [Vercel](https://vercel.com/) - a free hosting platform for serverless projects strongly integrated with Git.
A working code example is [available here](https://github.com/GabrielTK/VercelSlashCreate), is currently being hosted via Vercel and can be tested [with this invite link](https://discord.com/oauth2/authorize?client_id=619935227737014333&scope=bot%20applications.commands&permissions=8) (NOTE: The invite link by default includes Administrator permissions, but that should not change anything. If you feel uncomfortable with testing it this way, just change the `permissions` bit on the URL.