### PR TITLE
feat: Autocomplete options

### DIFF
--- a/docs/examples/command.md
+++ b/docs/examples/command.md
@@ -100,3 +100,37 @@ module.exports = class ReverseCommand extends SlashCommand {
   }
 }
 ```
+
+### Command with Autocompletable options
+```js
+const { SlashCommand, CommandOptionType } = require('slash-create');
+
+module.exports = class HelloCommand extends SlashCommand {
+  constructor(creator) {
+    super(creator, {
+      name: 'hello',
+      description: 'Says hello to you.',
+      options: [{
+        type: CommandOptionType.STRING,
+        name: 'greeting',
+        description: 'Enter a greeting!',
+        required: true,
+        autocomplete: true
+      }]
+    });
+
+    // Not required initially, but required for reloading with a fresh file.
+    this.filePath = __filename;
+  }
+
+  async autocomplete(ctx) {
+    // You can send a list of choices with `ctx.sendResults` or by returning a list of choices.
+    // Get the focused option name with `ctx.focused`.
+    return [{ name: `Your text: ${ctx.options[ctx.focused]}`, value: ctx.options[ctx.focused] }];
+  }
+
+  async run(ctx) {
+    return `> ${ctx.options.greeting}\nHello!`;
+  }
+}
+```

--- a/src/command.ts
+++ b/src/command.ts
@@ -8,6 +8,7 @@ import {
 import { CommandContext } from './structures/interfaces/commandContext';
 import { SlashCreator } from './creator';
 import { oneLine, validateOptions } from './util';
+import { AutocompleteContext } from './structures/interfaces/autocompleteContext';
 
 /** Represents a Discord slash command. */
 export class SlashCommand {
@@ -212,6 +213,14 @@ export class SlashCommand {
    */
   async run(ctx: CommandContext): Promise<any> { // eslint-disable-line @typescript-eslint/no-unused-vars, prettier/prettier
     throw new Error(`${this.constructor.name} doesn't have a run() method.`);
+  }
+
+  /**
+   * Runs an autocomplete function.
+   * @param ctx The context of the interaction
+   */
+  async autocomplete(ctx: AutocompleteContext): Promise<any> { // eslint-disable-line @typescript-eslint/no-unused-vars, prettier/prettier
+    throw new Error(`${this.constructor.name} doesn't have a autocomplete() method.`);
   }
 
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,6 +27,7 @@ export * from './structures/permissions';
 export * from './structures/user';
 export * from './structures/userFlags';
 
+export * from './structures/interfaces/autocompleteContext';
 export * from './structures/interfaces/componentContext';
 export * from './structures/interfaces/commandContext';
 export * from './structures/interfaces/messageInteraction';

--- a/src/structures/interfaces/autocompleteContext.ts
+++ b/src/structures/interfaces/autocompleteContext.ts
@@ -1,0 +1,112 @@
+import { AnyCommandOption, CommandAutocompleteRequestData, InteractionResponseType } from '../../constants';
+import { SlashCreator } from '../../creator';
+import { RespondFunction } from '../../server';
+import { Member } from '../member';
+import { User } from '../user';
+import { CommandContext } from './commandContext';
+
+/** Represents a autocomplete interaction context. */
+export class AutocompleteContext {
+  /** The full interaction data. */
+  readonly data: CommandAutocompleteRequestData;
+  /** The creator of the interaction request. */
+  readonly creator: SlashCreator;
+  /** The interaction's token. */
+  readonly interactionToken: string;
+  /** The interaction's ID. */
+  readonly interactionID: string;
+  /** The channel ID that the interaction was invoked in. */
+  readonly channelID: string;
+  /** The guild ID that the interaction was invoked in. */
+  readonly guildID?: string;
+  /** The member that invoked the interaction. */
+  readonly member?: Member;
+  /** The user that invoked the interaction. */
+  readonly user: User;
+  /** The options given to the command. */
+  readonly options: { [key: string]: any };
+  /** The option name that is currently focused.  */
+  readonly focused: string;
+  /** The subcommands the member used in order. */
+  readonly subcommands: string[];
+  /** The time when the interaction was created. */
+  readonly invokedAt: number = Date.now();
+
+  /** Whether the interaction has been responded to. */
+  responded = false;
+  /** @hidden */
+  private _respond: RespondFunction;
+
+  /**
+   * @param creator The instantiating creator.
+   * @param data The interaction data.
+   * @param respond The response function for the interaction.
+   */
+  constructor(creator: SlashCreator, data: CommandAutocompleteRequestData, respond: RespondFunction) {
+    this.creator = creator;
+    this._respond = respond;
+
+    this.data = data;
+    this.interactionToken = data.token;
+    this.interactionID = data.id;
+    this.channelID = data.channel_id;
+    this.guildID = 'guild_id' in data ? data.guild_id : undefined;
+    this.member = 'guild_id' in data ? new Member(data.member, this.creator) : undefined;
+    this.user = new User('guild_id' in data ? data.member.user : data.user, this.creator);
+    this.options = CommandContext.convertOptions(data.data.options);
+    this.subcommands = CommandContext.getSubcommandArray(data.data.options);
+    this.focused = AutocompleteContext.getFocusedOption(data.data.options)!;
+  }
+
+  /** Whether the interaction has expired. Interactions last 15 minutes. */
+  get expired() {
+    return this.invokedAt + 1000 * 60 * 15 < Date.now();
+  }
+
+  /**
+   * Sends the results of an autocomplete interaction.
+   * @param choices The choices to display
+   */
+  async sendResults(choices: AutocompleteChoice[]): Promise<boolean> {
+    if (this.responded) return false;
+
+    this.responded = true;
+    await this._respond({
+      status: 200,
+      body: {
+        type: InteractionResponseType.APPLICATION_COMMAND_AUTOCOMPLETE_RESULT,
+        data: { choices }
+      }
+    });
+    return true;
+  }
+
+  /** @private */
+  static convertOptions(options: AnyCommandOption[]) {
+    const convertedOptions: { [key: string]: any } = {};
+    for (const option of options) {
+      if ('options' in option)
+        convertedOptions[option.name] = option.options ? CommandContext.convertOptions(option.options) : {};
+      else convertedOptions[option.name] = 'value' in option && option.value !== undefined ? option.value : {};
+    }
+    return convertedOptions;
+  }
+
+  /** @private */
+  static getFocusedOption(options: AnyCommandOption[]): string | undefined {
+    for (const option of options) {
+      if ('focused' in option && option.focused) {
+        return option.name;
+      }
+      if ('options' in option && option.options) {
+        const nextResult = AutocompleteContext.getFocusedOption(option.options);
+        if (nextResult) return nextResult;
+      }
+    }
+  }
+}
+
+export interface AutocompleteChoice {
+  name: string;
+  value: string | number;
+}

--- a/test/__util__/constants.ts
+++ b/test/__util__/constants.ts
@@ -75,7 +75,7 @@ export const editedMessage: MessageData = {
 
 export const interactionDefaults: InteractionRequestData = {
   version: 1,
-  type: InteractionType.COMMAND,
+  type: InteractionType.APPLICATION_COMMAND,
   token: MOCK_TOKEN,
   id: '00000000000000000',
   channel_id: '00000000000000000',

--- a/test/__util__/constants.ts
+++ b/test/__util__/constants.ts
@@ -1,6 +1,7 @@
 import {
   ApplicationCommand,
   ApplicationCommandType,
+  CommandAutocompleteRequestData,
   CommandOptionType,
   ComponentType,
   InteractionRequestData,
@@ -232,6 +233,31 @@ export const subCommandOptionsInteraction: InteractionRequestData = {
             name: 'bool',
             type: CommandOptionType.BOOLEAN,
             value: true
+          }
+        ]
+      }
+    ]
+  }
+};
+
+export const autocompleteInteraction: CommandAutocompleteRequestData = {
+  ...interactionDefaults,
+  type: InteractionType.APPLICATION_COMMAND_AUTOCOMPLETE,
+  data: {
+    id: '0',
+    name: 'sub-command-opts',
+    type: ApplicationCommandType.CHAT_INPUT,
+    version: '0',
+    options: [
+      {
+        name: 'sub-command',
+        type: CommandOptionType.SUB_COMMAND,
+        options: [
+          {
+            name: 'string',
+            type: CommandOptionType.STRING,
+            value: 'incomplete str',
+            focused: true
           }
         ]
       }

--- a/test/structures/interfaces/autocompleteContext.ts
+++ b/test/structures/interfaces/autocompleteContext.ts
@@ -1,0 +1,18 @@
+import * as chai from 'chai';
+import 'mocha';
+const expect = chai.expect;
+
+import { creator, noop, autocompleteInteraction } from '../../__util__/constants';
+import { AutocompleteContext } from '../../../src/structures/interfaces/autocompleteContext';
+
+describe('AutocompleteContext', () => {
+  describe('constructor', () => {
+    it('assigns properties properly', async () => {
+      const ctx = new AutocompleteContext(creator, autocompleteInteraction, noop);
+
+      expect(ctx.options).to.deep.equal({ 'sub-command': { string: 'incomplete str' } });
+      expect(ctx.subcommands).to.deep.equal(['sub-command']);
+      expect(ctx.focused).to.equal('string');
+    });
+  });
+});


### PR DESCRIPTION
Adds [autocomplete stuff](https://devsnek.notion.site/devsnek/Application-Command-Option-Autocomplete-Interactions-dacc980320c948768cec5ae3a96a5886) to commands.

```ts
import { SlashCreator, SlashCommand, CommandOptionType, CommandContext, AutocompleteContext } from 'slash-create';

export default class ExampleCommand extends SlashCommand {
  constructor(creator: SlashCreator) {
    super(creator, {
      name: 'example',
      description: 'The.',
      options: [
        {
          type: CommandOptionType.STRING,
          name: 'astring',
          description: '...',
          autocomplete: true
        }
      ]
    });
  }

  async autocomplete(ctx: AutocompleteContext) {
    // Get the focused option name with `ctx.focused`
    // can use ctx.sendResults([{ name: 'A Title', value: 'a_value' }])
    // or return an array of choices
    return [{ name: `Your text: ${ctx.options[ctx.focused]}`, value: 'a_value' }]
  }

  async run(ctx: CommandContext) {
    // ...
  }
}
```

## Todo
- [x] implementation
- [x] tests
- [x] documentation w/ examples