### PR TITLE
Add role icon properties to ResolvedRole

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -455,11 +455,13 @@ export interface ResolvedRole {
   color: number;
   hoist: boolean;
   id: string;
+  icon?: string;
   managed: boolean;
   mentionable: boolean;
   name: string;
   permissions: string;
   position: number;
+  unicode_emoji?: string;
 }
 
 /** @private */

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -704,7 +704,8 @@ export const Endpoints = {
 
   // CDN
   DEFAULT_USER_AVATAR: (userDiscriminator: string | number) => `/embed/avatars/${userDiscriminator}`,
-  USER_AVATAR: (userID: string, userAvatar: string) => `/avatars/${userID}/${userAvatar}`
+  USER_AVATAR: (userID: string, userAvatar: string) => `/avatars/${userID}/${userAvatar}`,
+  ROLE_ICON: (roleID: string, roleIcon: string) => `/role-icons/${roleID}/${roleIcon}`
 };
 
 // SlashCreator events for documentation.

--- a/src/structures/interfaces/commandContext.ts
+++ b/src/structures/interfaces/commandContext.ts
@@ -82,7 +82,7 @@ export class CommandContext extends MessageInteractionContext {
         );
       if (data.data.resolved.roles)
         Object.keys(data.data.resolved.roles).forEach((id) =>
-          this.roles.set(id, new Role(data.data.resolved!.roles![id]))
+          this.roles.set(id, new Role(data.data.resolved!.roles![id], this.creator))
         );
       if (data.data.resolved.channels)
         Object.keys(data.data.resolved.channels).forEach((id) =>

--- a/src/structures/role.ts
+++ b/src/structures/role.ts
@@ -1,5 +1,6 @@
 /* global BigInt */
-import { ResolvedRole } from '../constants';
+import { CDN_URL, Endpoints, ImageFormat, ImageFormats, ImageSizeBoundaries, ResolvedRole } from '../constants';
+import { SlashCreator } from '../creator';
 import { Permissions } from './permissions';
 
 /** Represents a resolved role object. */
@@ -14,10 +15,17 @@ export class Role {
   readonly color: number;
   /** Whether the role is being hoisted */
   readonly hoist: boolean;
+  /** The role icon hash */
+  readonly icon?: string;
   /** Whether the role is being managed by an application */
   readonly managed: boolean;
   /** Whether the role is mentionable by everyone */
   readonly mentionable: boolean;
+  /** The role unicode emoji */
+  readonly unicodeEmoji?: string;
+
+  /** The creator of the role class. */
+  private _creator: SlashCreator;
 
   private _permissionsBitfield?: Permissions;
   private _permissions: string;
@@ -25,15 +33,42 @@ export class Role {
   /**
    * @param data The data for the member
    */
-  constructor(data: ResolvedRole) {
+  constructor(data: ResolvedRole, creator: SlashCreator) {
+    this._creator = creator;
+
     this.id = data.id;
     this.name = data.name;
     this.position = data.position;
     this.color = data.color;
     this.hoist = data.hoist;
+    if (data.icon) this.icon = data.icon;
     this.managed = data.managed;
     this.mentionable = data.mentionable;
+    if (data.unicode_emoji) this.unicodeEmoji = data.unicode_emoji;
     this._permissions = data.permissions;
+  }
+
+  /** The URL of the role icon. */
+  get iconURL() {
+    return this.dynamicIconURL();
+  }
+
+  /**
+   * Get the role's icon with the given format and size.
+   * @param format The format of the icon
+   * @param size The size of the icon
+   */
+  dynamicIconURL(format?: ImageFormat, size?: number) {
+    if (!this.icon) return null;
+    if (!format || !ImageFormats.includes(format.toLowerCase())) {
+      format = this._creator.options.defaultImageFormat;
+    }
+
+    if (!size || size < ImageSizeBoundaries.MINIMUM || size > ImageSizeBoundaries.MAXIMUM) {
+      size = this._creator.options.defaultImageSize;
+    }
+
+    return `${CDN_URL}${Endpoints.ROLE_ICON(this.id, this.icon)}.${format}?size=${size}`;
   }
 
   /** The string that mentions this role. */


### PR DESCRIPTION
## Added

- `Role#icon` as a nullable string which is an image hash if available *including icons as uploaded from custom emojis*.
- `Role#unicode_emoji` as a nullable string which is... a unicode emoji.
- `get Role#iconURL` -> `Role#dynamicIconURL()`
- `Role#dynamicIconURL(format?, size?)` which returns as `null` if `#icon` doesn't exist.
- `ROLE_ICON(format, size)` cdn route to Endpoints

*`Role#icon` and `Role#unicode_emoji` are reflected from `ResolvedRole` as it's sibling type definition.*