### PR TITLE
feat: Add member avatar endpoint with related methods

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -433,6 +433,7 @@ export type CommandAutocompleteRequestData = DMCommandAutocompleteRequestData | 
 
 /** @private */
 export interface ResolvedMemberData {
+  avatar?: string;
   roles: string[];
   premium_since: string | null;
   pending: boolean;
@@ -713,7 +714,8 @@ export const Endpoints = {
   // CDN
   DEFAULT_USER_AVATAR: (userDiscriminator: string | number) => `/embed/avatars/${userDiscriminator}`,
   USER_AVATAR: (userID: string, userAvatar: string) => `/avatars/${userID}/${userAvatar}`,
-  ROLE_ICON: (roleID: string, roleIcon: string) => `/role-icons/${roleID}/${roleIcon}`
+  ROLE_ICON: (roleID: string, roleIcon: string) => `/role-icons/${roleID}/${roleIcon}`,
+  GUILD_MEMBER_AVATAR: (guildID: string, memberID: string, memberAvatar: string) => `/guilds/${guildID}/users/${memberID}/avatars/${memberAvatar}`
 };
 
 // SlashCreator events for documentation.

--- a/src/structures/interfaces/autocompleteContext.ts
+++ b/src/structures/interfaces/autocompleteContext.ts
@@ -51,7 +51,7 @@ export class AutocompleteContext {
     this.interactionID = data.id;
     this.channelID = data.channel_id;
     this.guildID = 'guild_id' in data ? data.guild_id : undefined;
-    this.member = 'guild_id' in data ? new Member(data.member, this.creator) : undefined;
+    this.member = 'guild_id' in data ? new Member(data.member, this.creator, data.guild_id) : undefined;
     this.user = new User('guild_id' in data ? data.member.user : data.user, this.creator);
     this.options = CommandContext.convertOptions(data.data.options);
     this.subcommands = CommandContext.getSubcommandArray(data.data.options);

--- a/src/structures/interfaces/commandContext.ts
+++ b/src/structures/interfaces/commandContext.ts
@@ -77,7 +77,7 @@ export class CommandContext extends MessageInteractionContext {
         Object.keys(data.data.resolved.members).forEach((id) =>
           this.members.set(
             id,
-            new ResolvedMember(data.data.resolved!.members![id], data.data.resolved!.users![id], this.creator)
+            new ResolvedMember(data.data.resolved!.members![id], data.data.resolved!.users![id], this.creator, this.guildID!)
           )
         );
       if (data.data.resolved.roles)

--- a/src/structures/interfaces/messageInteraction.ts
+++ b/src/structures/interfaces/messageInteraction.ts
@@ -47,7 +47,7 @@ export class MessageInteractionContext {
     this.interactionID = data.id;
     this.channelID = data.channel_id;
     this.guildID = 'guild_id' in data ? data.guild_id : undefined;
-    this.member = 'guild_id' in data ? new Member(data.member, this.creator) : undefined;
+    this.member = 'guild_id' in data ? new Member(data.member, this.creator, data.guild_id) : undefined;
     this.user = new User('guild_id' in data ? data.member.user : data.user, this.creator);
   }
 

--- a/src/structures/member.ts
+++ b/src/structures/member.ts
@@ -18,8 +18,8 @@ export class Member extends ResolvedMember {
    * @param data The data for the member
    * @param creator The instantiating creator
    */
-  constructor(data: CommandMember, creator: SlashCreator) {
-    super(data, data.user, creator);
+  constructor(data: CommandMember, creator: SlashCreator, guildID: string) {
+    super(data, data.user, creator, guildID);
     this.mute = data.mute;
     this.deaf = data.deaf;
     this._permissions = data.permissions;

--- a/src/structures/resolvedMember.ts
+++ b/src/structures/resolvedMember.ts
@@ -21,6 +21,8 @@ export class ResolvedMember {
   readonly avatar?: string;
   /** The user object for this member */
   readonly user: User;
+  /** The ID of the guild this member belongs to. */
+  readonly guildID: string;
 
   /** The creator of the member class. */
   private readonly _creator: SlashCreator;
@@ -29,8 +31,9 @@ export class ResolvedMember {
    * @param data The data for the member
    * @param userData The data for the member's user
    * @param creator The instantiating creator
+   * @param guildID The ID of the guild this member belongs to
    */
-  constructor(data: ResolvedMemberData, userData: CommandUser, creator: SlashCreator) {
+  constructor(data: ResolvedMemberData, userData: CommandUser, creator: SlashCreator, guildID: string) {
     this._creator = creator;
 
     if (data.nick) this.nick = data.nick;
@@ -38,6 +41,7 @@ export class ResolvedMember {
     this.roles = data.roles;
     if (data.premium_since) this.premiumSince = Date.parse(data.premium_since);
     this.pending = data.pending;
+    this.guildID = guildID;
 
     this.id = userData.id;
     if(data.avatar) this.avatar = data.avatar;
@@ -73,6 +77,6 @@ export class ResolvedMember {
       size = this._creator.options.defaultImageSize;
     }
 
-    return `${CDN_URL}${Endpoints.GUILD_MEMBER_AVATAR(null /* guildID - not available */, this.id, this.avatar)}.${format}?size=${size}`;
+    return `${CDN_URL}${Endpoints.GUILD_MEMBER_AVATAR(this.guildID, this.id, this.avatar)}.${format}?size=${size}`;
   }
 }

--- a/src/structures/resolvedMember.ts
+++ b/src/structures/resolvedMember.ts
@@ -1,5 +1,12 @@
-import { CDN_URL, Endpoints, ImageFormat, ImageFormats, ImageSizeBoundaries } from '..';
-import { CommandUser, ResolvedMemberData } from '../constants';
+import {
+  CommandUser,
+  ResolvedMemberData,
+  CDN_URL,
+  Endpoints,
+  ImageFormat,
+  ImageFormats,
+  ImageSizeBoundaries
+} from '../constants';
 import { SlashCreator } from '../creator';
 import { User } from './user';
 
@@ -44,7 +51,7 @@ export class ResolvedMember {
     this.guildID = guildID;
 
     this.id = userData.id;
-    if(data.avatar) this.avatar = data.avatar;
+    if (data.avatar) this.avatar = data.avatar;
     this.user = new User(userData, creator);
   }
 
@@ -69,11 +76,11 @@ export class ResolvedMember {
   }
 
   dynamicAvatarURL(format?: ImageFormat, size?: number) {
-    if(!this.avatar) return this.user.dynamicAvatarURL(format, size);
-    if(!format || !ImageFormats.includes(format.toLowerCase())) {
+    if (!this.avatar) return this.user.dynamicAvatarURL(format, size);
+    if (!format || !ImageFormats.includes(format.toLowerCase())) {
       format = this.avatar.startsWith('a_') ? 'gif' : this._creator.options.defaultImageFormat;
     }
-    if(!size || size < ImageSizeBoundaries.MINIMUM || size > ImageSizeBoundaries.MAXIMUM) {
+    if (!size || size < ImageSizeBoundaries.MINIMUM || size > ImageSizeBoundaries.MAXIMUM) {
       size = this._creator.options.defaultImageSize;
     }
 


### PR DESCRIPTION
## Added

- `ResolvedMember#avatarURL()`
- `ResolvedMember#dynamicAvatarURL(format?: ImageFormat, size?: number)`
- `ResolvedMemberData.avatar?`

---

- `ResolvedMember` and `Member` (as child of the former) now take a `guildID` argument **after** the `creator` argument.
  > Existence of `guildID` is guaranteed if `Member` or `ResolvedMember` is instantiated.

## Aside

* `ResolvedMember#id` *can* also be converted into a getter since it's from `userData`.
* `ResolvedMember#is_pending` is not a property of the [GuildMember](https://discord.dev/docs/resources/guild#guild-member-object) structure (partial or not).