### PR TITLE
feat: add wildcard components

### DIFF
--- a/src/creator.ts
+++ b/src/creator.ts
@@ -694,11 +694,14 @@ export class SlashCreator extends (EventEmitter as any as new () => TypedEventEm
 
           const componentCallbackKey = `${ctx.message.id}-${ctx.customID}`;
           const globalCallbackKey = `global-${ctx.customID}`;
+          const wildcardCallbackKey = `${ctx.message.id}-*`;
 
           if (this._componentCallbacks.has(componentCallbackKey))
             return this._componentCallbacks.get(componentCallbackKey)!.callback(ctx);
           if (this._componentCallbacks.has(globalCallbackKey))
             return this._componentCallbacks.get(globalCallbackKey)!.callback(ctx);
+          if (this._componentCallbacks.has(wildcardCallbackKey))
+            return this._componentCallbacks.get(wildcardCallbackKey)!.callback(ctx);
           break;
         } else
           return respond({

--- a/src/structures/interfaces/messageInteraction.ts
+++ b/src/structures/interfaces/messageInteraction.ts
@@ -262,13 +262,14 @@ export class MessageInteractionContext {
    * @param callback The callback to use on interaction
    * @param expiration The expiration time of the callback in milliseconds. Use null for no expiration (Although, in this case, global components might be more consistent).
    * @param onExpired A function to be called when the component expires.
+   * @returns A function to unregister the component.
    */
   registerComponent(
     custom_id: string,
     callback: ComponentRegisterCallback,
     expiration: number = 1000 * 60 * 15,
     onExpired?: () => void
-  ) {
+  ): ComponentUnregisterCallback {
     if (this.expired) throw new Error('This interaction has expired');
     if (!this.initiallyResponded || this.deferred)
       throw new Error('You must send a message before registering components');
@@ -280,6 +281,8 @@ export class MessageInteractionContext {
       expires: expiration != null ? this.invokedAt + expiration : undefined,
       onExpired
     });
+
+    return () => this.unregisterComponent(custom_id);
   }
 
   /**
@@ -290,6 +293,7 @@ export class MessageInteractionContext {
    * @param callback The callback to use on interaction
    * @param expiration The expiration time of the callback in milliseconds. Use null for no expiration (Although, in this case, global components might be more consistent).
    * @param onExpired A function to be called when the component expires.
+   * @returns A function to unregister the component.
    */
   registerComponentFrom(
     message_id: string,
@@ -297,7 +301,7 @@ export class MessageInteractionContext {
     callback: ComponentRegisterCallback,
     expiration: number = 1000 * 60 * 15,
     onExpired?: () => void
-  ) {
+  ): ComponentUnregisterCallback {
     if (this.expired) throw new Error('This interaction has expired');
     if (!this.initiallyResponded || this.deferred)
       throw new Error('You must send a message before registering components');
@@ -307,6 +311,8 @@ export class MessageInteractionContext {
       expires: expiration != null ? this.invokedAt + expiration : undefined,
       onExpired
     });
+
+    return () => this.unregisterComponent(custom_id, message_id);
   }
 
   /**
@@ -329,13 +335,14 @@ export class MessageInteractionContext {
    * @param callback The callback to use on interaction
    * @param expiration The expiration time of the callback in milliseconds. Use null for no expiration (Although, in this case, global components might be more consistent).
    * @param onExpired A function to be called when the component expires.
+   * @returns A function to unregister the component
    */
   registerWildcardComponent(
     message_id: string,
     callback: ComponentRegisterCallback,
     expiration: number = 1000 * 60 * 15,
     onExpired?: () => void
-  ) {
+  ): ComponentUnregisterCallback {
     if (this.expired) throw new Error('This interaction has expired');
     if (!this.initiallyResponded || this.deferred)
       throw new Error('You must send a message before registering components');
@@ -345,6 +352,8 @@ export class MessageInteractionContext {
       expires: expiration != null ? this.invokedAt + expiration : undefined,
       onExpired
     });
+
+    return () => this.unregisterWildcardComponent(message_id);
   }
 
   /**
@@ -360,6 +369,9 @@ export class MessageInteractionContext {
     return this.creator._componentCallbacks.delete(`${message_id}-*`);
   }
 }
+
+/** A function to unregister a component callback, returns the boolean result from the method called. */
+export type ComponentUnregisterCallback = () => boolean;
 
 /** The options for {@link MessageInteractionContext#edit}. */
 export interface EditMessageOptions {

--- a/src/structures/interfaces/messageInteraction.ts
+++ b/src/structures/interfaces/messageInteraction.ts
@@ -350,7 +350,6 @@ export class MessageInteractionContext {
   /**
    * Unregisters a component callback.
    * @param message_id The message ID of the component to unregister, defaults to the invoking message ID.
-   * @returns 
    */
   unregisterWildcardComponent(message_id: string) {
     if (!message_id) {

--- a/src/structures/interfaces/messageInteraction.ts
+++ b/src/structures/interfaces/messageInteraction.ts
@@ -262,14 +262,13 @@ export class MessageInteractionContext {
    * @param callback The callback to use on interaction
    * @param expiration The expiration time of the callback in milliseconds. Use null for no expiration (Although, in this case, global components might be more consistent).
    * @param onExpired A function to be called when the component expires.
-   * @returns A function to unregister the component.
    */
   registerComponent(
     custom_id: string,
     callback: ComponentRegisterCallback,
     expiration: number = 1000 * 60 * 15,
     onExpired?: () => void
-  ): ComponentUnregisterCallback {
+  ) {
     if (this.expired) throw new Error('This interaction has expired');
     if (!this.initiallyResponded || this.deferred)
       throw new Error('You must send a message before registering components');
@@ -281,8 +280,6 @@ export class MessageInteractionContext {
       expires: expiration != null ? this.invokedAt + expiration : undefined,
       onExpired
     });
-
-    return () => this.unregisterComponent(custom_id);
   }
 
   /**
@@ -293,7 +290,6 @@ export class MessageInteractionContext {
    * @param callback The callback to use on interaction
    * @param expiration The expiration time of the callback in milliseconds. Use null for no expiration (Although, in this case, global components might be more consistent).
    * @param onExpired A function to be called when the component expires.
-   * @returns A function to unregister the component.
    */
   registerComponentFrom(
     message_id: string,
@@ -301,7 +297,7 @@ export class MessageInteractionContext {
     callback: ComponentRegisterCallback,
     expiration: number = 1000 * 60 * 15,
     onExpired?: () => void
-  ): ComponentUnregisterCallback {
+  ) {
     if (this.expired) throw new Error('This interaction has expired');
 
     this.creator._componentCallbacks.set(`${message_id}-${custom_id}`, {
@@ -309,8 +305,6 @@ export class MessageInteractionContext {
       expires: expiration != null ? this.invokedAt + expiration : undefined,
       onExpired
     });
-
-    return () => this.unregisterComponent(custom_id, message_id);
   }
 
   /**
@@ -333,14 +327,13 @@ export class MessageInteractionContext {
    * @param callback The callback to use on interaction
    * @param expiration The expiration time of the callback in milliseconds. Use null for no expiration (Although, in this case, global components might be more consistent).
    * @param onExpired A function to be called when the component expires.
-   * @returns A function to unregister the component
    */
   registerWildcardComponent(
     message_id: string,
     callback: ComponentRegisterCallback,
     expiration: number = 1000 * 60 * 15,
     onExpired?: () => void
-  ): ComponentUnregisterCallback {
+  ) {
     if (this.expired) throw new Error('This interaction has expired');
 
     this.creator._componentCallbacks.set(`${message_id}-*`, {
@@ -348,8 +341,6 @@ export class MessageInteractionContext {
       expires: expiration != null ? this.invokedAt + expiration : undefined,
       onExpired
     });
-
-    return () => this.unregisterWildcardComponent(message_id);
   }
 
   /**
@@ -360,9 +351,6 @@ export class MessageInteractionContext {
     return this.creator._componentCallbacks.delete(`${message_id}-*`);
   }
 }
-
-/** A function to unregister a component callback, returns the boolean result from the method called. */
-export type ComponentUnregisterCallback = () => boolean;
 
 /** The options for {@link MessageInteractionContext#edit}. */
 export interface EditMessageOptions {

--- a/src/structures/interfaces/messageInteraction.ts
+++ b/src/structures/interfaces/messageInteraction.ts
@@ -322,6 +322,14 @@ export class MessageInteractionContext {
     return this.creator._componentCallbacks.delete(`${message_id}-${custom_id}`);
   }
 
+  /**
+   * Registers a wildcard component callback on a message.
+   * This unregisters automatically when the context expires.
+   * @param message_id The message ID of the component to register
+   * @param callback The callback to use on interaction
+   * @param expiration The expiration time of the callback in milliseconds. Use null for no expiration (Although, in this case, global components might be more consistent).
+   * @param onExpired A function to be called when the component expires.
+   */
   registerWildcardComponent(
     message_id: string,
     callback: ComponentRegisterCallback,
@@ -331,7 +339,7 @@ export class MessageInteractionContext {
     if (this.expired) throw new Error('This interaction has expired');
     if (!this.initiallyResponded || this.deferred)
       throw new Error('You must send a message before registering components');
-    
+
     this.creator._componentCallbacks.set(`${message_id}-*`, {
       callback,
       expires: expiration != null ? this.invokedAt + expiration : undefined,
@@ -339,6 +347,11 @@ export class MessageInteractionContext {
     });
   }
 
+  /**
+   * Unregisters a component callback.
+   * @param message_id The message ID of the component to unregister, defaults to the invoking message ID.
+   * @returns 
+   */
   unregisterWildcardComponent(message_id: string) {
     if (!message_id) {
       if (!this.messageID) throw new Error('The initial message ID was not provided by the context!');

--- a/src/structures/interfaces/messageInteraction.ts
+++ b/src/structures/interfaces/messageInteraction.ts
@@ -321,6 +321,32 @@ export class MessageInteractionContext {
     }
     return this.creator._componentCallbacks.delete(`${message_id}-${custom_id}`);
   }
+
+  registerWildcardComponent(
+    callback: ComponentRegisterCallback,
+    message_id: string,
+    expiration: number = 1000 * 60 * 15,
+    onExpired?: () => void
+  ) {
+    if (this.expired) throw new Error('This interaction has expired');
+    if (!this.initiallyResponded || this.deferred)
+      throw new Error('You must send a message before registering components');
+    
+    this.creator._componentCallbacks.set(`${message_id}-*`, {
+      callback,
+      expires: expiration != null ? this.invokedAt + expiration : undefined,
+      onExpired
+    });
+  }
+
+  unregisterWildcardComponent(message_id: string) {
+    if (!message_id) {
+      if (!this.messageID) throw new Error('The initial message ID was not provided by the context!');
+      else message_id = this.messageID;
+    }
+
+    return this.creator._componentCallbacks.delete(`${message_id}-*`);
+  }
 }
 
 /** The options for {@link MessageInteractionContext#edit}. */

--- a/src/structures/interfaces/messageInteraction.ts
+++ b/src/structures/interfaces/messageInteraction.ts
@@ -303,8 +303,6 @@ export class MessageInteractionContext {
     onExpired?: () => void
   ): ComponentUnregisterCallback {
     if (this.expired) throw new Error('This interaction has expired');
-    if (!this.initiallyResponded || this.deferred)
-      throw new Error('You must send a message before registering components');
 
     this.creator._componentCallbacks.set(`${message_id}-${custom_id}`, {
       callback,
@@ -344,8 +342,6 @@ export class MessageInteractionContext {
     onExpired?: () => void
   ): ComponentUnregisterCallback {
     if (this.expired) throw new Error('This interaction has expired');
-    if (!this.initiallyResponded || this.deferred)
-      throw new Error('You must send a message before registering components');
 
     this.creator._componentCallbacks.set(`${message_id}-*`, {
       callback,
@@ -361,11 +357,6 @@ export class MessageInteractionContext {
    * @param message_id The message ID of the component to unregister, defaults to the invoking message ID.
    */
   unregisterWildcardComponent(message_id: string) {
-    if (!message_id) {
-      if (!this.messageID) throw new Error('The initial message ID was not provided by the context!');
-      else message_id = this.messageID;
-    }
-
     return this.creator._componentCallbacks.delete(`${message_id}-*`);
   }
 }

--- a/src/structures/interfaces/messageInteraction.ts
+++ b/src/structures/interfaces/messageInteraction.ts
@@ -323,8 +323,8 @@ export class MessageInteractionContext {
   }
 
   registerWildcardComponent(
-    callback: ComponentRegisterCallback,
     message_id: string,
+    callback: ComponentRegisterCallback,
     expiration: number = 1000 * 60 * 15,
     onExpired?: () => void
   ) {


### PR DESCRIPTION
This extends further from #145 by adding a listener for all components on a message as a wildcard - the component used can be determined by [`ctx.custom_id`](https://slash-create.js.org/#/docs/main/latest/class/ComponentContext?scrollTo=customID).

- [x] Method Docs / Descriptions

### Added

- `MessageInteractionContext#registerWildcardComponent(message_id, callback, expiration, onExpired)`
- `MessageInteractionContext#unregisterWildcardComponent(message_id)`

*Wildcard components use the invoking message ID with an asterisk (`*`) to prevent possible conflicts with existing registered components.*

For context sake, this was implemented with eda121e ([Gist Component](https://gist.github.com/sudojunior/e720cc1083c08d1258e9835d692b49b1)) with a specific use for ephemeral components (and having it unregister itself immediately before invoking the callback).