### PR TITLE
patch(dep): Force usage of `djs/collection@0.2.4`

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "node": ">=14"
   },
   "dependencies": {
-    "@discordjs/collection": "^0.4.0",
+    "@discordjs/collection": "0.2.4",
     "eventemitter3": "^4.0.7",
     "lodash.isequal": "^4.5.0",
     "tweetnacl": "^1.0.3"


### PR DESCRIPTION
- Prior to the implimentation of Node v16 package requirement
- Loss of access to `reverse`, `ensure` (`0.4.x`)
- Loss of access to `at` and `keyAt` (`0.3.x`)

Last available release at 27th October 2021.
Full diff changeset: https://github.com/discordjs/collection/compare/v0.2.1...v0.4.0