### PR TITLE
feat: allow ack for `ModalInteractionContext`

### DIFF
--- a/src/structures/interfaces/modalInteractionContext.ts
+++ b/src/structures/interfaces/modalInteractionContext.ts
@@ -1,4 +1,9 @@
-import { ComponentActionRow, ComponentTextInput, ModalSubmitRequestData } from '../../constants';
+import {
+  ComponentActionRow,
+  ComponentTextInput,
+  InteractionResponseType,
+  ModalSubmitRequestData
+} from '../../constants';
 import { SlashCreator } from '../../creator';
 import { RespondFunction } from '../../server';
 import { MessageInteractionContext } from './messageInteraction';
@@ -37,5 +42,25 @@ export class ModalInteractionContext extends MessageInteractionContext {
     }
 
     return values;
+  }
+
+  /**
+   * Acknowledges the interaction without replying.
+   * @returns Whether the acknowledgement passed passed
+   */
+  async acknowledge(): Promise<boolean> {
+    if (!this.initiallyResponded) {
+      this.initiallyResponded = true;
+      clearTimeout(this._timeout);
+      await this._respond({
+        status: 200,
+        body: {
+          type: InteractionResponseType.DEFERRED_UPDATE_MESSAGE
+        }
+      });
+      return true;
+    }
+
+    return false;
   }
 }

--- a/src/structures/interfaces/modalInteractionContext.ts
+++ b/src/structures/interfaces/modalInteractionContext.ts
@@ -46,7 +46,7 @@ export class ModalInteractionContext extends MessageInteractionContext {
 
   /**
    * Acknowledges the interaction without replying.
-   * @returns Whether the acknowledgement passed passed
+   * @returns Whether the acknowledgement passed
    */
   async acknowledge(): Promise<boolean> {
     if (!this.initiallyResponded) {


### PR DESCRIPTION
* method cloned from `ComponentContext`

possibility was suggested by @mount2010 for skipping deferral