### PR TITLE
feat: Add `#editParent` and `#data` to `ModalInteractionContext`

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -328,6 +328,7 @@ export interface DMModalSubmitRequestData {
   channel_id: string;
   locale?: string;
   user: CommandUser;
+  message?: MessageData;
   data: {
     custom_id: string;
     components: ComponentActionRow[];
@@ -349,6 +350,7 @@ export interface GuildModalSubmitRequestData {
   locale?: string;
   guild_locale?: string;
   member: CommandMember;
+  message?: MessageData;
   data: {
     custom_id: string;
     components: ComponentActionRow[];

--- a/src/structures/interfaces/modalInteractionContext.ts
+++ b/src/structures/interfaces/modalInteractionContext.ts
@@ -12,6 +12,8 @@ import { EditMessageOptions, MessageInteractionContext } from './messageInteract
 
 /** Represents an interaction context from a modal submission. */
 export class ModalInteractionContext extends MessageInteractionContext {
+  /** The request data. */
+  readonly data: ModalSubmitRequestData;
   /** The ID of the component to identify its origin from. */
   readonly customID: string;
   /** The message this interaction came from, will be partial for ephemeral messages. */
@@ -29,6 +31,7 @@ export class ModalInteractionContext extends MessageInteractionContext {
   constructor(creator: SlashCreator, data: ModalSubmitRequestData, respond: RespondFunction, useTimeout = true) {
     super(creator, data, respond);
 
+    this.data = data;
     this.customID = data.data.custom_id;
     this.values = ModalInteractionContext.convertComponents(data.data.components);
 

--- a/src/structures/interfaces/modalInteractionContext.ts
+++ b/src/structures/interfaces/modalInteractionContext.ts
@@ -1,12 +1,21 @@
-import { ComponentActionRow, ComponentTextInput, ModalSubmitRequestData } from '../../constants';
+import {
+  ComponentActionRow,
+  ComponentTextInput,
+  InteractionResponseType,
+  ModalSubmitRequestData
+} from '../../constants';
 import { SlashCreator } from '../../creator';
 import { RespondFunction } from '../../server';
-import { MessageInteractionContext } from './messageInteraction';
+import { formatAllowedMentions, FormattedAllowedMentions } from '../../util';
+import { Message } from '../message';
+import { EditMessageOptions, MessageInteractionContext } from './messageInteraction';
 
 /** Represents an interaction context from a modal submission. */
 export class ModalInteractionContext extends MessageInteractionContext {
   /** The ID of the component to identify its origin from. */
   readonly customID: string;
+  /** The message this interaction came from, will be partial for ephemeral messages. */
+  readonly message?: Message;
 
   /** The values defined in the modal submission. */
   readonly values: { [key: string]: string };
@@ -23,6 +32,7 @@ export class ModalInteractionContext extends MessageInteractionContext {
     this.customID = data.data.custom_id;
     this.values = ModalInteractionContext.convertComponents(data.data.components);
 
+    if (data.message) this.message = new Message(data.message, creator, this);
     // Auto-defer if no response was given in 2 seconds
     if (useTimeout) this._timeout = setTimeout(() => this.defer(false), 2000);
   }
@@ -37,5 +47,47 @@ export class ModalInteractionContext extends MessageInteractionContext {
     }
 
     return values;
+  }
+
+  /**
+   * Edits the message that the component interaction came from.
+   * This will return a boolean if it's an initial response, otherwise a {@link Message} will be returned.
+   * @param content The content of the message
+   * @param options The message options
+   */
+  async editParent(content: string | EditMessageOptions, options?: EditMessageOptions): Promise<boolean | Message> {
+    if (this.expired) throw new Error('This interaction has expired');
+    if (!this.message) throw new Error('This interaction has no message');
+
+    if (typeof content !== 'string') options = content;
+    else if (typeof options !== 'object') options = {};
+
+    if (typeof options !== 'object') throw new Error('Message options is not an object.');
+
+    if (!options.content && typeof content === 'string') options.content = content;
+
+    if (!options.content && !options.embeds && !options.components) throw new Error('No valid options were given.');
+
+    const allowedMentions = options.allowedMentions
+      ? formatAllowedMentions(options.allowedMentions, this.creator.allowedMentions as FormattedAllowedMentions)
+      : this.creator.allowedMentions;
+
+    if (!this.initiallyResponded) {
+      this.initiallyResponded = true;
+      clearTimeout(this._timeout);
+      await this._respond({
+        status: 200,
+        body: {
+          type: InteractionResponseType.UPDATE_MESSAGE,
+          data: {
+            content: options.content,
+            embeds: options.embeds,
+            allowed_mentions: allowedMentions,
+            components: options.components
+          }
+        }
+      });
+      return true;
+    } else return this.edit(this.message.id, content, options);
   }
 }

--- a/src/structures/interfaces/modalInteractionContext.ts
+++ b/src/structures/interfaces/modalInteractionContext.ts
@@ -93,4 +93,46 @@ export class ModalInteractionContext extends MessageInteractionContext {
       return true;
     } else return this.edit(this.message.id, content, options);
   }
+
+  /*
+   * Edits the message that the component interaction came from.
+   * This will return a boolean if it's an initial response, otherwise a {@link Message} will be returned.
+   * @param content The content of the message
+   * @param options The message options
+   */
+  async editParent(content: string | EditMessageOptions, options?: EditMessageOptions): Promise<boolean | Message> {
+    if (this.expired) throw new Error('This interaction has expired');
+    if (!this.message) throw new Error('This interaction has no message');
+
+    if (typeof content !== 'string') options = content;
+    else if (typeof options !== 'object') options = {};
+
+    if (typeof options !== 'object') throw new Error('Message options is not an object.');
+
+    if (!options.content && typeof content === 'string') options.content = content;
+
+    if (!options.content && !options.embeds && !options.components) throw new Error('No valid options were given.');
+
+    const allowedMentions = options.allowedMentions
+      ? formatAllowedMentions(options.allowedMentions, this.creator.allowedMentions as FormattedAllowedMentions)
+      : this.creator.allowedMentions;
+
+    if (!this.initiallyResponded) {
+      this.initiallyResponded = true;
+      clearTimeout(this._timeout);
+      await this._respond({
+        status: 200,
+        body: {
+          type: InteractionResponseType.UPDATE_MESSAGE,
+          data: {
+            content: options.content,
+            embeds: options.embeds,
+            allowed_mentions: allowedMentions,
+            components: options.components
+          }
+        }
+      });
+      return true;
+    } else return this.edit(this.message.id, content, options);
+  }
 }


### PR DESCRIPTION
* `ModalInteractionContext` - both new members are akin to the close relative of `ComponentContext`
  * Added `#data`
    > Allowing possible workarounds for any new additions Discord makes if the library is not updated in time.
  * Added `#message` for modal contexts that originate from a Message Component.
  * Added `#editParent(content, options)`
    > This will check for existence from the payload before attempting to patch the message itself.

It has been noted that this kind of contribution is discouraged with how the library is structured, and beginning to see code repeated across it's interfaces. The possibility of having a `BaseInteractionContext` class to have all _contexts_ derive from was a future alternative that was discussed to contain the core elements of any *non-ping* interaction `data`, `interactionID`, `interactionToken`, etc. etc.

For now, `MessageInteractionContext` covers the core elements of the classes that derive from it - but sibling contexts will continue to carry responsibility until the weight is redistributed.