### PR TITLE
feat: add command localizations

### DIFF
--- a/docs/examples/command.md
+++ b/docs/examples/command.md
@@ -255,3 +255,49 @@ module.exports = class ModalCommand extends SlashCommand {
   }
 }
 ```
+
+### Localized Command
+Check [here](https://discord.com/developers/docs/reference#locales) for supported locale codes, this example uses German.
+```js
+const { SlashCommand, CommandOptionType } = require('slash-create');
+
+module.exports = class HelloCommand extends SlashCommand {
+  constructor(creator) {
+    super(creator, {
+      name: 'hello',
+      nameLocalizations: {
+        de: 'hallo'
+      },
+
+      description: 'Says hello to you.',
+      descriptionLocalizations: {
+        de: 'Sagt hallo zu dir.
+      },
+
+      // It's important to note that since option localization is passed straight to Discord, the prop names are snake cased.
+      options: [{
+        type: CommandOptionType.STRING,
+
+        name: 'food',
+        name_localizations: {
+          de: 'lebensmittel'
+        },
+
+        description: 'What food do you like?',
+        description_localizations: {
+          de: 'Welches Essen magst du?'
+        }
+      }]
+    });
+
+    this.filePath = __filename;
+  }
+
+  async run(ctx) {
+    // ctx.locale
+    // ctx.guildLocale
+
+    return ctx.options.food ? `You like ${ctx.options.food}? Nice!` : `Hello, ${ctx.user.username}!`;
+  }
+}
+```

--- a/docs/examples/command.md
+++ b/docs/examples/command.md
@@ -293,6 +293,12 @@ module.exports = class HelloCommand extends SlashCommand {
     this.filePath = __filename;
   }
 
+  // If you use any package like i18next and need to asyncronously set localization, this function is ran right before syncing the command.
+  async onLocaleUpdate() {
+    // this.nameLocalizations['da'] = i18next.getFixedT('da')('command.hello.name');
+    // this.ddescriptionLocalizationse['da'] = i18next.getFixedT('da')('command.hello.description');
+  }
+
   async run(ctx) {
     // ctx.locale
     // ctx.guildLocale

--- a/src/command.ts
+++ b/src/command.ts
@@ -14,10 +14,14 @@ import { AutocompleteContext } from './structures/interfaces/autocompleteContext
 export class SlashCommand<T = any> {
   /** The command's name. */
   readonly commandName: string;
+  /** The localiztions for the command name. */
+  readonly nameLocalizations?: Record<string, string>;
   /** The type of command this is. */
   readonly type: ApplicationCommandType;
   /** The command's description. */
   readonly description?: string;
+  /** The localiztions for the command description. */
+  readonly descriptionLocalizations?: Record<string, string>;
   /** The options for the command. */
   readonly options?: ApplicationCommandOption[];
   /** The guild ID(s) for the command. */
@@ -64,7 +68,9 @@ export class SlashCommand<T = any> {
 
     this.type = opts.type || ApplicationCommandType.CHAT_INPUT;
     this.commandName = opts.name;
+    if (opts.nameLocalizations) this.nameLocalizations = opts.nameLocalizations;
     if (opts.description) this.description = opts.description;
+    if (opts.descriptionLocalizations) this.nameLocalizations = opts.descriptionLocalizations;
     this.options = opts.options;
     if (opts.guildIDs) this.guildIDs = typeof opts.guildIDs == 'string' ? [opts.guildIDs] : opts.guildIDs;
     this.requiredPermissions = opts.requiredPermissions;
@@ -83,13 +89,16 @@ export class SlashCommand<T = any> {
     return this.type === ApplicationCommandType.CHAT_INPUT
       ? {
           name: this.commandName,
+          ...(this.nameLocalizations ? { name_localizations: this.nameLocalizations } : {}),
           description: this.description,
+          ...(this.descriptionLocalizations ? { description_localizations: this.descriptionLocalizations } : {}),
           default_permission: this.defaultPermission,
           type: ApplicationCommandType.CHAT_INPUT,
           ...(this.options ? { options: this.options } : {})
         }
       : {
           name: this.commandName,
+          ...(this.nameLocalizations ? { name_localizations: this.nameLocalizations } : {}),
           description: '',
           type: this.type,
           default_permission: this.defaultPermission
@@ -296,8 +305,12 @@ export interface SlashCommandOptions {
   type?: ApplicationCommandType;
   /** The name of the command. */
   name: string;
+  /** The localiztions for the command name. */
+  nameLocalizations?: Record<string, string>;
   /** The description of the command. */
   description?: string;
+  /** The localiztions for the command description. */
+  descriptionLocalizations?: Record<string, string>;
   /** The guild ID(s) that this command will be assigned to. */
   guildIDs?: string | string[];
   /** The required permission(s) for this command. */

--- a/src/command.ts
+++ b/src/command.ts
@@ -15,15 +15,15 @@ export class SlashCommand<T = any> {
   /** The command's name. */
   readonly commandName: string;
   /** The localiztions for the command name. */
-  readonly nameLocalizations?: Record<string, string>;
+  nameLocalizations?: Record<string, string>;
   /** The type of command this is. */
   readonly type: ApplicationCommandType;
   /** The command's description. */
   readonly description?: string;
   /** The localiztions for the command description. */
-  readonly descriptionLocalizations?: Record<string, string>;
+  descriptionLocalizations?: Record<string, string>;
   /** The options for the command. */
-  readonly options?: ApplicationCommandOption[];
+  options?: ApplicationCommandOption[];
   /** The guild ID(s) for the command. */
   readonly guildIDs?: string[];
   /** The permissions required to use this command. */
@@ -178,6 +178,11 @@ export class SlashCommand<T = any> {
     if (!ctx.expired && !ctx.initiallyResponded)
       return ctx.send('An error occurred while running the command.', { ephemeral: true });
   }
+
+  /**
+   * Called when the command's localization is requesting to be updated.
+   */
+  onLocaleUpdate(): any {}
 
   /**
    * Called when the command is being unloaded.

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -129,8 +129,12 @@ export enum ChannelType {
 export interface PartialApplicationCommand {
   /** The name of the command. */
   name: string;
+  /** The localiztions for the command name. */
+  name_localizations?: Record<string, string>;
   /** The description of the command. */
   description?: string;
+  /** The localiztions for the command description. */
+  description_localizations?: Record<string, string>;
   /** The options for the command. */
   options?: ApplicationCommandOption[];
   /** Whether to enable this command for everyone by default. */
@@ -245,6 +249,10 @@ export interface ApplicationCommandOptionChoice {
   name: string;
   /** The value of the choice. */
   value: string | number;
+  /** The localiztions for the option name. */
+  name_localizations?: Record<string, string>;
+  /** The localiztions for the option description. */
+  description_localizations?: Record<string, string>;
 }
 
 /** The type of thing to apply the permission to. */

--- a/src/creator.ts
+++ b/src/creator.ts
@@ -340,6 +340,7 @@ export class SlashCreator extends (EventEmitter as any as new () => TypedEventEm
           'debug',
           `Found guild command "${applicationCommand.name}" (${applicationCommand.id}, type ${applicationCommand.type}, guild: ${guildID})`
         );
+        await command.onLocaleUpdate();
         updatePayload.push({
           id: applicationCommand.id,
           ...command.commandJSON
@@ -370,6 +371,7 @@ export class SlashCreator extends (EventEmitter as any as new () => TypedEventEm
 
     for (const [, command] of unhandledCommands) {
       this.emit('debug', `Creating guild command "${command.commandName}" (type ${command.type}, guild: ${guildID})`);
+      await command.onLocaleUpdate();
       updatePayload.push({
         ...command.commandJSON
       });
@@ -414,6 +416,7 @@ export class SlashCreator extends (EventEmitter as any as new () => TypedEventEm
           'debug',
           `Found command "${applicationCommand.name}" (${applicationCommand.id}, type ${applicationCommand.type})`
         );
+        await command.onLocaleUpdate();
         updatePayload.push({
           id: applicationCommand.id,
           ...command.commandJSON
@@ -444,6 +447,7 @@ export class SlashCreator extends (EventEmitter as any as new () => TypedEventEm
 
     for (const [, command] of unhandledCommands) {
       this.emit('debug', `Creating command "${command.commandName}" (type ${command.type})`);
+      await command.onLocaleUpdate();
       updatePayload.push({
         ...command.commandJSON
       });


### PR DESCRIPTION
From https://github.com/discord/discord-api-docs/pull/4653

Will test later, *might* have a way to asynchronously get localizations for potential integrations with i18next with some async function named `onLoad`.