### PR TITLE
feat: initial response attachments support

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -139,13 +139,15 @@ export class SlashCreatorAPI {
    * @param interactionID The interaction's ID.
    * @param interactionToken The interaction's token.
    * @param body The body to send.
+   * @param files The files to send.
    */
-  interactionCallback(interactionID: string, interactionToken: string, body: any): Promise<unknown> {
+  interactionCallback(interactionID: string, interactionToken: string, body: any, files?: any[]): Promise<unknown> {
     return this._creator.requestHandler.request(
       'POST',
       Endpoints.INTERACTION_CALLBACK(interactionID, interactionToken),
       false,
-      body
+      body,
+      files
     );
   }
 }

--- a/src/creator.ts
+++ b/src/creator.ts
@@ -835,7 +835,7 @@ export class SlashCreator extends (EventEmitter as any as new () => TypedEventEm
 
   private _createGatewayRespond(interactionID: string, token: string): RespondFunction {
     return async (response: Response) => {
-      await this.api.interactionCallback(interactionID, token, response.body);
+      await this.api.interactionCallback(interactionID, token, response.body, response.files);
     };
   }
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -73,6 +73,8 @@ export interface Response {
   headers?: { [key: string]: string | string[] | undefined };
   /** The body of the response. */
   body?: any;
+  /** The files of the response. */
+  files?: any[];
 }
 
 /**

--- a/src/servers/gcf.ts
+++ b/src/servers/gcf.ts
@@ -1,6 +1,7 @@
 import { Server, ServerRequestHandler } from '../server';
 // @ts-ignore
 import * as Express from 'express';
+import { MultipartData } from '../util/multipartData';
 
 /**
  * A server for Google Cloud Functions.
@@ -31,7 +32,13 @@ export class GCFServer extends Server {
       async (response) => {
         res.status(response.status || 200);
         if (response.headers) for (const key in response.headers) res.set(key, response.headers[key]);
-        res.send(response.body);
+        if (response.files) {
+          const data = new MultipartData();
+          res.set('Content-Type', 'multipart/form-data; boundary=' + data.boundary);
+          for (const file of response.files) data.attach(file.name, file.file, file.name);
+          data.attach('payload_json', JSON.stringify(response.body));
+          res.send(Buffer.concat(data.finish()));
+        } else res.send(response.body);
       }
     );
   }

--- a/src/servers/vercel.ts
+++ b/src/servers/vercel.ts
@@ -1,6 +1,7 @@
 import { Server, ServerRequestHandler } from '../server';
 // @ts-ignore
 import { VercelRequest, VercelResponse } from '@vercel/node';
+import { MultipartData } from '../util/multipartData';
 
 /**
  * A server for Vercel.
@@ -28,7 +29,13 @@ export class VercelServer extends Server {
       async (response) => {
         res.status(response.status || 200);
         if (response.headers) for (const key in response.headers) res.setHeader(key, response.headers[key] as string);
-        res.send(response.body);
+        if (response.files) {
+          const data = new MultipartData();
+          res.setHeader('Content-Type', 'multipart/form-data; boundary=' + data.boundary);
+          for (const file of response.files) data.attach(file.name, file.file, file.name);
+          data.attach('payload_json', JSON.stringify(response.body));
+          res.send(Buffer.concat(data.finish()));
+        } else res.send(response.body);
       }
     );
   };

--- a/src/structures/interfaces/componentContext.ts
+++ b/src/structures/interfaces/componentContext.ts
@@ -94,7 +94,8 @@ export class ComponentContext extends ModalSendableContext {
             allowed_mentions: allowedMentions,
             components: options.components
           }
-        }
+        },
+        files: options.file ? (Array.isArray(options.file) ? options.file : [options.file]) : undefined
       });
       return true;
     } else return this.edit(this.message.id, content, options);

--- a/src/structures/interfaces/messageInteraction.ts
+++ b/src/structures/interfaces/messageInteraction.ts
@@ -121,7 +121,8 @@ export class MessageInteractionContext {
             allowed_mentions: allowedMentions,
             components: options.components
           }
-        }
+        },
+        files: options.file ? (Array.isArray(options.file) ? options.file : [options.file]) : undefined
       });
       return true;
     } else if (this.initiallyResponded && this.deferred) return this.editOriginal(content, options);

--- a/src/structures/interfaces/modalInteractionContext.ts
+++ b/src/structures/interfaces/modalInteractionContext.ts
@@ -108,7 +108,8 @@ export class ModalInteractionContext extends MessageInteractionContext {
             allowed_mentions: allowedMentions,
             components: options.components
           }
-        }
+        },
+        files: options.file ? (Array.isArray(options.file) ? options.file : [options.file]) : undefined
       });
       return true;
     } else return this.edit(this.message.id, content, options);


### PR DESCRIPTION
Allow for initial messages to have attachments.

Servers to support:
- [x] Azure
- [x] Express
- [x] Fastify
- [x] Gateway
- [x] GCF
- [x] AWS Lambda
- [x] Vercel
- Cloudflare Workers (in seperate repo)