### PR TITLE
refactor: Permissions V2 Rework

### DIFF
--- a/docs/examples/command.md
+++ b/docs/examples/command.md
@@ -31,26 +31,18 @@ module.exports = class ExclusivityCommand extends SlashCommand {
   constructor(creator) {
     super(creator, {
       name: 'exclusivity',
-      description: 'Only Snazzah can use this command.',
+      description: 'Only people who manage the guild can use this command.',
       // Whether to enable this command for everyone by default
       defaultPermission: false,
-      // Permissions are mapped by guild ID like this
-      permissions: {
-        '<guild_id>': [
-          {
-            type: ApplicationCommandPermissionType.USER,
-            id: '158049329150427136',
-            permission: true
-          }
-        ]
-      }
+      // This will be an array of permission flag names from here: https://discord.dev/topics/permissions#permissions-bitwise-permission-flags
+      requiredPermissions: ['MANAGE_GUILD']
     });
 
     this.filePath = __filename;
   }
 
   async run(ctx) {
-    return 'Hi Snazzah!';
+    return 'You can manage this guild!';
   }
 }
 ```

--- a/src/api.ts
+++ b/src/api.ts
@@ -122,6 +122,7 @@ export class SlashCreatorAPI {
     );
   }
 
+  /** @deprecated Command permissions have been deprecated: https://link.snaz.in/sc-cpd */
   bulkUpdateCommandPermissions(
     guildID: string,
     commands: PartialApplicationCommandPermissions[]

--- a/src/command.ts
+++ b/src/command.ts
@@ -9,6 +9,7 @@ import { CommandContext } from './structures/interfaces/commandContext';
 import { SlashCreator } from './creator';
 import { oneLine, validateOptions } from './util';
 import { AutocompleteContext } from './structures/interfaces/autocompleteContext';
+import { Permissions } from './structures/permissions';
 
 /** Represents a Discord slash command. */
 export class SlashCommand<T = any> {
@@ -27,15 +28,20 @@ export class SlashCommand<T = any> {
   /** The guild ID(s) for the command. */
   readonly guildIDs?: string[];
   /** The permissions required to use this command. */
-  readonly requiredPermissions?: Array<string>;
+  readonly requiredPermissions?: string[];
   /** The throttling options for this command. */
   readonly throttling?: ThrottlingOptions;
   /** Whether this command is used for unknown commands. */
   readonly unknown: boolean;
   /** Whether responses from this command should defer ephemeral messages. */
   readonly deferEphemeral: boolean;
-  /** Whether to enable this command for everyone by default. */
+  /**
+   * Whether to enable this command for everyone by default.'
+   * @deprecated
+   */
   readonly defaultPermission: boolean;
+  /** Whether to enable this command in direct messages. */
+  readonly dmPermission: boolean;
   /** The command permissions per guild. */
   readonly permissions?: CommandPermissions;
   /**
@@ -78,12 +84,14 @@ export class SlashCommand<T = any> {
     this.unknown = opts.unknown || false;
     this.deferEphemeral = opts.deferEphemeral || false;
     this.defaultPermission = typeof opts.defaultPermission === 'boolean' ? opts.defaultPermission : true;
+    this.dmPermission = typeof opts.dmPermission === 'boolean' ? opts.dmPermission : true;
     if (opts.permissions) this.permissions = opts.permissions;
   }
 
   /**
    * The JSON for using commands in Discord's API.
    * @private
+   * @deprecated
    */
   get commandJSON(): PartialApplicationCommand {
     return this.type === ApplicationCommandType.CHAT_INPUT
@@ -103,6 +111,32 @@ export class SlashCommand<T = any> {
           type: this.type,
           default_permission: this.defaultPermission
         };
+  }
+
+  /**
+   * The command object serialized into JSON.
+   * @param global Whether the command is global or not.
+   */
+  toCommandJSON(global = true): PartialApplicationCommand {
+    return {
+      type: this.type,
+      name: this.commandName,
+      ...(this.nameLocalizations ? { name_localizations: this.nameLocalizations } : {}),
+      ...(this.type === ApplicationCommandType.CHAT_INPUT
+        ? {
+            description: this.description,
+            ...(this.descriptionLocalizations ? { description_localizations: this.descriptionLocalizations } : {}),
+            ...(this.options ? { options: this.options } : {})
+          }
+        : {
+            description: ''
+          }),
+      default_permission: this.defaultPermission,
+      ...(global ? { dm_permission: this.dmPermission } : {}),
+      default_member_permissions: this.requiredPermissions
+        ? new Permissions(this.requiredPermissions).valueOf().toString()
+        : null
+    };
   }
 
   /**
@@ -328,8 +362,13 @@ export interface SlashCommandOptions {
   unknown?: boolean;
   /** Whether responses from this command should defer ephemeral messages. */
   deferEphemeral?: boolean;
-  /** Whether to enable this command for everyone by default. `true` by default. */
+  /**
+   * Whether to enable this command for everyone by default. `true` by default.
+   * @deprecated
+   */
   defaultPermission?: boolean;
+  /** Whether to enable this command in direct messages. `true` by default. */
+  dmPermission?: boolean;
   /** The command permissions per guild */
   permissions?: CommandPermissions;
 }

--- a/src/command.ts
+++ b/src/command.ts
@@ -167,12 +167,12 @@ export class SlashCommand<T = any> {
       if (missing.length > 0) {
         if (missing.length === 1) {
           return `The \`${this.commandName}\` command requires you to have the "${
-            PermissionNames[missing[0]]
+            PermissionNames[missing[0]] || missing[0]
           }" permission.`;
         }
         return oneLine`
           The \`${this.commandName}\` command requires you to have the following permissions:
-          ${missing.map((perm) => PermissionNames[perm]).join(', ')}
+          ${missing.map((perm) => PermissionNames[perm] || perm).join(', ')}
         `;
       }
     }
@@ -322,7 +322,7 @@ export class SlashCommand<T = any> {
       if (!Array.isArray(opts.requiredPermissions))
         throw new TypeError('Command required permissions must be an Array of permission key strings.');
       for (const perm of opts.requiredPermissions)
-        if (!PermissionNames[perm]) throw new RangeError(`Invalid command required permission: ${perm}`);
+        if (!Permissions.FLAGS[perm]) throw new RangeError(`Invalid command required permission: ${perm}`);
     }
 
     if (opts.throttling) {

--- a/src/command.ts
+++ b/src/command.ts
@@ -42,7 +42,10 @@ export class SlashCommand<T = any> {
   readonly defaultPermission: boolean;
   /** Whether to enable this command in direct messages. */
   readonly dmPermission: boolean;
-  /** The command permissions per guild. */
+  /**
+   * The command permissions per guild.
+   * @deprecated Command permissions have been deprecated: https://link.snaz.in/sc-cpd
+   */
   readonly permissions?: CommandPermissions;
   /**
    * The file path of the command.
@@ -91,7 +94,7 @@ export class SlashCommand<T = any> {
   /**
    * The JSON for using commands in Discord's API.
    * @private
-   * @deprecated
+   * @deprecated Use {@link SlashCommand#toCommandJSON} instead.
    */
   get commandJSON(): PartialApplicationCommand {
     return this.type === ApplicationCommandType.CHAT_INPUT
@@ -353,7 +356,7 @@ export interface SlashCommandOptions {
   /** The guild ID(s) that this command will be assigned to. */
   guildIDs?: string | string[];
   /** The required permission(s) for this command. */
-  requiredPermissions?: Array<string>;
+  requiredPermissions?: string[];
   /** The command's options. */
   options?: ApplicationCommandOption[];
   /** The throttling options for the command. */
@@ -364,12 +367,15 @@ export interface SlashCommandOptions {
   deferEphemeral?: boolean;
   /**
    * Whether to enable this command for everyone by default. `true` by default.
-   * @deprecated
+   * @deprecated Use {@link SlashCommandOptions.requiredPermissions} and {@link SlashCommandOptions.dmPermission} instead.
    */
   defaultPermission?: boolean;
   /** Whether to enable this command in direct messages. `true` by default. */
   dmPermission?: boolean;
-  /** The command permissions per guild */
+  /**
+   * The command permissions per guild
+   * @deprecated Command permissions have been deprecated: https://link.snaz.in/sc-cpd
+   */
   permissions?: CommandPermissions;
 }
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -139,6 +139,10 @@ export interface PartialApplicationCommand {
   options?: ApplicationCommandOption[];
   /** Whether to enable this command for everyone by default. */
   default_permission?: boolean;
+  /** Whether to enable this command in direct messages. */
+  dm_permission?: boolean | null;
+  /** The member permissions required to use this command. */
+  default_member_permissions?: string | null;
   /** The type of application this is representing. `1` by default. */
   type?: ApplicationCommandType;
 }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -264,7 +264,9 @@ export enum ApplicationCommandPermissionType {
   /** A Discord role. */
   ROLE = 1,
   /** A Discord user. */
-  USER = 2
+  USER = 2,
+  /** A Discord channel. */
+  CHANNEL = 3
 }
 
 /** A permission in a command. */

--- a/src/creator.ts
+++ b/src/creator.ts
@@ -462,6 +462,7 @@ export class SlashCreator extends (EventEmitter as any as new () => TypedEventEm
   /**
    * Sync command permissions.
    * <warn>This requires you to have your token set in the creator config AND have commands already synced previously.</warn>
+   * @deprecated Command permissions have been deprecated: https://link.snaz.in/sc-cpd
    */
   async syncCommandPermissions() {
     const guildPayloads: { [guildID: string]: PartialApplicationCommandPermissions[] } = {};
@@ -480,7 +481,11 @@ export class SlashCreator extends (EventEmitter as any as new () => TypedEventEm
       }
     }
 
-    for (const guildID in guildPayloads) await this.api.bulkUpdateCommandPermissions(guildID, guildPayloads[guildID]);
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    for (const guildID in guildPayloads) {
+      this.emit('warn', 'Syncing command permissions has been deprecated and will be removed in the future.');
+      // await this.api.bulkUpdateCommandPermissions(guildID, guildPayloads[guildID]);
+    }
   }
 
   /**
@@ -926,7 +931,10 @@ interface SyncCommandOptions {
    * Guild syncs most likely can error if that guild no longer exists.
    */
   skipGuildErrors?: boolean;
-  /** Whether to sync command permissions after syncing commands. */
+  /**
+   * Whether to sync command permissions after syncing commands.
+   * @deprecated Command permissions have been deprecated: https://link.snaz.in/sc-cpd
+   */
   syncPermissions?: boolean;
 }
 

--- a/src/creator.ts
+++ b/src/creator.ts
@@ -323,7 +323,6 @@ export class SlashCreator extends (EventEmitter as any as new () => TypedEventEm
       delete (partialCommand as any).guild_id;
       delete (partialCommand as any).id;
       delete (partialCommand as any).version;
-      delete (partialCommand as any).default_member_permissions;
 
       const command = this.commands.find(
         (command) =>
@@ -343,7 +342,7 @@ export class SlashCreator extends (EventEmitter as any as new () => TypedEventEm
         if (command.onLocaleUpdate) await command.onLocaleUpdate();
         updatePayload.push({
           id: applicationCommand.id,
-          ...command.commandJSON
+          ...command.toCommandJSON(false)
         });
         handledCommands.push(command.keyName);
       } else if (deleteCommands) {
@@ -360,7 +359,6 @@ export class SlashCreator extends (EventEmitter as any as new () => TypedEventEm
       delete (cmd as any).application_id;
       delete (cmd as any).guild_id;
       delete (cmd as any).version;
-      delete (cmd as any).default_member_permissions;
       return cmd;
     });
 
@@ -406,8 +404,6 @@ export class SlashCreator extends (EventEmitter as any as new () => TypedEventEm
       delete (partialCommand as any).application_id;
       delete (partialCommand as any).id;
       delete (partialCommand as any).version;
-      delete (partialCommand as any).default_member_permissions;
-      delete (partialCommand as any).dm_permission;
 
       const command = this.commands.get(commandKey);
       if (command) {
@@ -419,7 +415,7 @@ export class SlashCreator extends (EventEmitter as any as new () => TypedEventEm
         if (command.onLocaleUpdate) await command.onLocaleUpdate();
         updatePayload.push({
           id: applicationCommand.id,
-          ...command.commandJSON
+          ...command.toCommandJSON()
         });
       } else if (deleteCommands) {
         this.emit(
@@ -436,8 +432,6 @@ export class SlashCreator extends (EventEmitter as any as new () => TypedEventEm
     const commandsPayload = commands.map((cmd) => {
       delete (cmd as any).application_id;
       delete (cmd as any).version;
-      delete (cmd as any).default_member_permissions;
-      delete (cmd as any).dm_permission;
       return cmd;
     });
 
@@ -449,7 +443,7 @@ export class SlashCreator extends (EventEmitter as any as new () => TypedEventEm
       this.emit('debug', `Creating command "${command.commandName}" (type ${command.type})`);
       if (command.onLocaleUpdate) await command.onLocaleUpdate();
       updatePayload.push({
-        ...command.commandJSON
+        ...command.toCommandJSON()
       });
     }
 

--- a/src/creator.ts
+++ b/src/creator.ts
@@ -371,7 +371,7 @@ export class SlashCreator extends (EventEmitter as any as new () => TypedEventEm
       this.emit('debug', `Creating guild command "${command.commandName}" (type ${command.type}, guild: ${guildID})`);
       if (command.onLocaleUpdate) await command.onLocaleUpdate();
       updatePayload.push({
-        ...command.commandJSON
+        ...command.toCommandJSON(false)
       });
     }
 

--- a/src/structures/permissions.ts
+++ b/src/structures/permissions.ts
@@ -37,7 +37,10 @@ const FLAGS: { [perm: string]: bigint } = {
   MANAGE_THREADS: 1n << 34n,
   USE_PUBLIC_THREADS: 1n << 35n,
   USE_PRIVATE_THREADS: 1n << 36n,
-  USE_EXTERNAL_STICKERS: 1n << 37n
+  USE_EXTERNAL_STICKERS: 1n << 37n,
+  SEND_MESSAGES_IN_THREADS: 1n << 38n,
+  USE_EMBEDDED_ACTIVITIES: 1n << 39n,
+  MODERATE_MEMBERS: 1n << 40n
 };
 
 /**

--- a/test/__util__/commands.ts
+++ b/test/__util__/commands.ts
@@ -1,23 +1,9 @@
-import { SlashCommand, CommandPermissions, ThrottlingOptions } from '../../src/command';
-import { ApplicationCommandOption } from '../../src/constants';
+import { SlashCommand, SlashCommandOptions } from '../../src/command';
 import { CommandContext } from '../../src/structures/interfaces/commandContext';
 import { SlashCreator } from '../../src/creator';
 
-interface SlashCommandPartialOptions {
-  name?: string;
-  description?: string;
-  guildIDs?: string | string[];
-  requiredPermissions?: Array<string>;
-  options?: ApplicationCommandOption[];
-  throttling?: ThrottlingOptions;
-  unknown?: boolean;
-  deferEphemeral?: boolean;
-  defaultPermission?: boolean;
-  permissions?: CommandPermissions;
-}
-
 export const createBasicCommand = (
-  opts: SlashCommandPartialOptions = {},
+  opts: Partial<SlashCommandOptions> = {},
   ids: [string, string][] = [],
   cb: (ctx: CommandContext) => any = () => {}
 ) => {

--- a/test/__util__/nock.ts
+++ b/test/__util__/nock.ts
@@ -1,5 +1,5 @@
 import nock from 'nock';
-import { API_BASE_URL, ApplicationCommand, Endpoints, GuildApplicationCommandPermissions } from '../../src/constants';
+import { API_BASE_URL, ApplicationCommand, Endpoints } from '../../src/constants';
 import { MOCK_TOKEN } from './constants';
 
 const DISCORD_URL = 'https://discord.com';
@@ -66,18 +66,6 @@ export const deleteGuildCommand = (id: string) =>
   nock(DISCORD_URL)
     .delete(API_BASE_URL + Endpoints.GUILD_COMMAND('1', '123', id))
     .reply(204, undefined, NOCK_HEADERS);
-// #endregion
-
-// #region Command Permissions
-export const guildCommandPermissions = (commands: GuildApplicationCommandPermissions[] = []) =>
-  nock(DISCORD_URL)
-    .get(API_BASE_URL + Endpoints.GUILD_COMMAND_PERMISSIONS('1', '123'))
-    .reply(200, commands, NOCK_HEADERS);
-
-export const updateGuildCommandPermissions = (commands: GuildApplicationCommandPermissions[] = []) =>
-  nock(DISCORD_URL)
-    .put(API_BASE_URL + Endpoints.GUILD_COMMAND_PERMISSIONS('1', '123'))
-    .reply(200, commands, NOCK_HEADERS);
 // #endregion
 
 // #region Interactions

--- a/test/creator.ts
+++ b/test/creator.ts
@@ -222,7 +222,7 @@ describe('SlashCreator', () => {
         .registerCommand(
           createBasicCommand({
             name: 'to-update',
-            defaultPermission: false,
+            dmPermission: false,
             permissions: {
               '123': [
                 {
@@ -278,14 +278,18 @@ describe('SlashCreator', () => {
       await expect(putScope, 'updates commands').to.have.been.requestedWith([
         {
           id: '1',
-          default_permission: false,
+          default_member_permissions: null,
+          default_permission: true,
+          dm_permission: false,
           name: 'to-update',
           description: 'description',
           type: ApplicationCommandType.CHAT_INPUT
         },
         {
           id: '3',
+          default_member_permissions: null,
           default_permission: true,
+          dm_permission: true,
           name: 'to-leave-alone',
           description: 'description',
           type: ApplicationCommandType.CHAT_INPUT
@@ -294,6 +298,7 @@ describe('SlashCreator', () => {
       await expect(guildCmdsScope, 'requests guild commands').to.have.been.requested;
       await expect(putGuildScope, 'updates guild commands').to.have.been.requestedWith([
         {
+          default_member_permissions: null,
           default_permission: true,
           name: 'to-create-guild',
           description: 'description',
@@ -345,6 +350,7 @@ describe('SlashCreator', () => {
       await expect(putScope, 'updates commands').to.have.been.requestedWith([
         {
           id: '1',
+          default_member_permissions: null,
           default_permission: true,
           name: 'to-update',
           description: 'description',
@@ -352,12 +358,14 @@ describe('SlashCreator', () => {
         },
         {
           id: '3',
+          default_member_permissions: null,
           default_permission: true,
           name: 'to-leave-alone',
           description: 'description',
           type: ApplicationCommandType.CHAT_INPUT
         },
         {
+          default_member_permissions: null,
           default_permission: true,
           name: 'to-create',
           description: 'description',
@@ -396,20 +404,26 @@ describe('SlashCreator', () => {
       await expect(putScope, 'updates commands').to.have.been.requestedWith([
         {
           id: '1',
+          default_member_permissions: null,
           default_permission: true,
+          dm_permission: true,
           name: 'to-update',
           description: 'description',
           type: ApplicationCommandType.CHAT_INPUT
         },
         {
           id: '3',
+          default_member_permissions: null,
           default_permission: true,
+          dm_permission: true,
           name: 'to-leave-alone',
           description: 'description',
           type: ApplicationCommandType.CHAT_INPUT
         },
         {
+          default_member_permissions: null,
           default_permission: true,
+          dm_permission: true,
           name: 'to-create',
           description: 'description',
           type: ApplicationCommandType.CHAT_INPUT

--- a/test/creator.ts
+++ b/test/creator.ts
@@ -10,16 +10,10 @@ import { SlashCreator } from '../src/creator';
 import { FastifyServer } from '../src/servers/fastify';
 import { GatewayServer } from '../src/servers/gateway';
 import { GCFServer } from '../src/servers/gcf';
-import { ApplicationCommandPermissionType, ApplicationCommandType } from '../src/constants';
+import { ApplicationCommandType } from '../src/constants';
 import { createBasicCommand } from './__util__/commands';
 import { basicCommands } from './__util__/constants';
-import {
-  globalCommands,
-  guildCommands,
-  updateGlobalCommands,
-  updateGuildCommandPermissions,
-  updateGuildCommands
-} from './__util__/nock';
+import { globalCommands, guildCommands, updateGlobalCommands, updateGuildCommands } from './__util__/nock';
 
 describe('SlashCreator', () => {
   describe('constructor', () => {
@@ -222,16 +216,7 @@ describe('SlashCreator', () => {
         .registerCommand(
           createBasicCommand({
             name: 'to-update',
-            dmPermission: false,
-            permissions: {
-              '123': [
-                {
-                  type: ApplicationCommandPermissionType.USER,
-                  id: '1',
-                  permission: true
-                }
-              ]
-            }
+            dmPermission: false
           })
         )
         .registerCommand(createBasicCommand({ name: 'to-leave-alone' }));
@@ -256,20 +241,6 @@ describe('SlashCreator', () => {
             application_id: '1',
             version: '1',
             type: ApplicationCommandType.CHAT_INPUT
-          }
-        ]),
-        permissionsScope = updateGuildCommandPermissions([
-          {
-            application_id: '1',
-            id: '1',
-            guild_id: '123',
-            permissions: [
-              {
-                type: ApplicationCommandPermissionType.USER,
-                id: '1',
-                permission: true
-              }
-            ]
           }
         ]);
 
@@ -303,18 +274,6 @@ describe('SlashCreator', () => {
           name: 'to-create-guild',
           description: 'description',
           type: ApplicationCommandType.CHAT_INPUT
-        }
-      ]);
-      await expect(permissionsScope, 'updates command permissions').to.have.been.requestedWith([
-        {
-          id: '1',
-          permissions: [
-            {
-              type: ApplicationCommandPermissionType.USER,
-              id: '1',
-              permission: true
-            }
-          ]
         }
       ]);
     });
@@ -430,62 +389,6 @@ describe('SlashCreator', () => {
         }
       ]);
       return promise;
-    });
-  });
-
-  describe('.syncCommandPermissions()', () => {
-    it('syncs command permissions correctly', async () => {
-      const creator = new SlashCreator({
-        applicationID: '1',
-        token: 'xxx'
-      });
-
-      creator.registerCommand(
-        createBasicCommand(
-          {
-            name: 'to-update',
-            permissions: {
-              '123': [
-                {
-                  type: ApplicationCommandPermissionType.USER,
-                  id: '1',
-                  permission: true
-                }
-              ]
-            }
-          },
-          [['123', '1']]
-        )
-      );
-
-      const permissionsScope = updateGuildCommandPermissions([
-        {
-          application_id: '1',
-          id: '1',
-          guild_id: '123',
-          permissions: [
-            {
-              type: ApplicationCommandPermissionType.USER,
-              id: '1',
-              permission: true
-            }
-          ]
-        }
-      ]);
-
-      creator.syncCommandPermissions();
-      await expect(permissionsScope, 'updates command permissions').to.have.been.requestedWith([
-        {
-          id: '1',
-          permissions: [
-            {
-              type: ApplicationCommandPermissionType.USER,
-              id: '1',
-              permission: true
-            }
-          ]
-        }
-      ]);
     });
   });
 


### PR DESCRIPTION
https://github.com/discord/discord-api-docs/pull/4830

- [x] Refactor command JSON, adding `dm_permission` and `default_member_permissions`, deperecating `default_permission`
- [x] new `CHANNEL` permission type
- [x] Deprecate batch command permission editing endpoint, ~~use manual permission checking requests~~