### PR TITLE
fix: reflect changes on ctx.edit from a1e2972

### DIFF
--- a/src/structures/interfaces/messageInteraction.ts
+++ b/src/structures/interfaces/messageInteraction.ts
@@ -190,7 +190,8 @@ export class MessageInteractionContext {
 
     if (!options.content && typeof content === 'string') options.content = content;
 
-    if (!options.content && !options.embeds && !options.components) throw new Error('No valid options were given.');
+    if (!options.content && !options.embeds && !options.components && !options.file)
+      throw new Error('No valid options were given.');
 
     const allowedMentions = options.allowedMentions
       ? formatAllowedMentions(options.allowedMentions, this.creator.allowedMentions as FormattedAllowedMentions)


### PR DESCRIPTION
This brings changes from a1e2972 after the release of [v5.5.3](https://github.com/Snazzah/slash-create/compare/v5.5.2...v5.5.3). It wasn't made apparent of the problems with file handling until it was raised in Discord after an interaction is `defer`-red and then `send(...)` is called with the arguments sent forward to `editOriginal(...)` and then `edit(...)` in subsequent order.

As such, no tests exist for this kind of file handling - no tests at all to construct a message from scratch (which does require the type disparity between `MessageOptions` and `MessageData` or any derivatives of them).

[Link to context (discord.com)](https://discord.com/channels/311027228177727508/794713212229910548/996032889978355713) error occurs at L151 because of compiled code, which resulted in my incorrect guesswork.