### PR TITLE
patch: modify multipart logic to support attachment IDs / indexes

### DIFF
--- a/src/structures/interfaces/messageInteraction.ts
+++ b/src/structures/interfaces/messageInteraction.ts
@@ -118,7 +118,7 @@ export class MessageInteractionContext {
       : this.creator.allowedMentions;
 
     if (!this.initiallyResponded) {
-      const resolvedAttachmentData = options.attachments ?? formatAttachmentData(options.file);
+      const resolvedAttachmentData = formatAttachmentData(options.file);
 
       this.initiallyResponded = true;
       clearTimeout(this._timeout);
@@ -164,7 +164,7 @@ export class MessageInteractionContext {
 
     if (options.ephemeral && !options.flags) options.flags = InteractionResponseFlags.EPHEMERAL;
 
-    const resolvedAttachmentData = options.attachments ?? formatAttachmentData(options.file);
+    const resolvedAttachmentData = formatAttachmentData(options.file);
     const allowedMentions = options.allowedMentions
       ? formatAllowedMentions(options.allowedMentions, this.creator.allowedMentions as FormattedAllowedMentions)
       : this.creator.allowedMentions;
@@ -207,7 +207,7 @@ export class MessageInteractionContext {
     if (!options.content && !options.embeds && !options.components && !options.file)
       throw new Error('No valid options were given.');
 
-    const resolvedAttachmentData = options.attachments ?? formatAttachmentData(options.file);
+    const resolvedAttachmentData = formatAttachmentData(options.file);
     const allowedMentions = options.allowedMentions
       ? formatAllowedMentions(options.allowedMentions, this.creator.allowedMentions as FormattedAllowedMentions)
       : this.creator.allowedMentions;
@@ -418,17 +418,19 @@ export interface EditMessageOptions {
   /** The components of the message. */
   components?: ComponentActionRow[];
   /** The attachment data of the message. */
-  attachments?: MessageAttachmentOptions[];
+  // attachments?: MessageAttachmentOptions[];
 }
 
 /** A file within {@link EditMessageOptions}. */
 export interface MessageFile {
   /** The attachment to send. */
-  file: Buffer;
+  file?: Buffer;
   /** The name of the file. */
   name: string;
   /** The index of the file. */
-  id?: number;
+  id?: string | number;
+  /** The description of the file. */
+  description?: string;
 }
 
 /** A message attachment describing a file. */

--- a/src/structures/interfaces/messageInteraction.ts
+++ b/src/structures/interfaces/messageInteraction.ts
@@ -426,7 +426,7 @@ export interface MessageFile {
 export interface MessageAttachmentOptions {
   /** The name of the attachment. */
   name?: string;
-  /** The index of the attachment. */
+  /** The ID of the attachment. For existing attachments, this must be the ID snowflake of the attachment, otherwise, this will be the index of the files being sent to Discord. */
   id: string | number;
   /** The description of the attachment. */
   description?: string;

--- a/src/structures/interfaces/messageInteraction.ts
+++ b/src/structures/interfaces/messageInteraction.ts
@@ -1,12 +1,7 @@
 import { ComponentActionRow, Endpoints, InteractionResponseFlags, InteractionResponseType } from '../../constants';
 import { SlashCreator, ComponentRegisterCallback } from '../../creator';
 import { RespondFunction } from '../../server';
-import {
-  formatAllowedMentions,
-  formatAttachmentData,
-  FormattedAllowedMentions,
-  MessageAllowedMentions
-} from '../../util';
+import { formatAllowedMentions, FormattedAllowedMentions, MessageAllowedMentions } from '../../util';
 import { Member } from '../member';
 import { User } from '../user';
 import { Message, MessageEmbedOptions } from '../message';
@@ -118,8 +113,6 @@ export class MessageInteractionContext {
       : this.creator.allowedMentions;
 
     if (!this.initiallyResponded) {
-      const resolvedAttachmentData = formatAttachmentData(options.file);
-
       this.initiallyResponded = true;
       clearTimeout(this._timeout);
       await this._respond({
@@ -133,7 +126,7 @@ export class MessageInteractionContext {
             flags: options.flags,
             allowed_mentions: allowedMentions,
             components: options.components,
-            attachments: resolvedAttachmentData
+            attachments: options.attachments
           }
         },
         files: options.file ? (Array.isArray(options.file) ? options.file : [options.file]) : undefined
@@ -164,7 +157,6 @@ export class MessageInteractionContext {
 
     if (options.ephemeral && !options.flags) options.flags = InteractionResponseFlags.EPHEMERAL;
 
-    const resolvedAttachmentData = formatAttachmentData(options.file);
     const allowedMentions = options.allowedMentions
       ? formatAllowedMentions(options.allowedMentions, this.creator.allowedMentions as FormattedAllowedMentions)
       : this.creator.allowedMentions;
@@ -180,7 +172,7 @@ export class MessageInteractionContext {
         allowed_mentions: allowedMentions,
         components: options.components,
         flags: options.flags,
-        attachments: resolvedAttachmentData
+        attachments: options.attachments
       },
       options.file
     );
@@ -204,10 +196,9 @@ export class MessageInteractionContext {
 
     if (!options.content && typeof content === 'string') options.content = content;
 
-    if (!options.content && !options.embeds && !options.components && !options.file)
+    if (!options.content && !options.embeds && !options.components && !options.file && !options.attachments)
       throw new Error('No valid options were given.');
 
-    const resolvedAttachmentData = formatAttachmentData(options.file);
     const allowedMentions = options.allowedMentions
       ? formatAllowedMentions(options.allowedMentions, this.creator.allowedMentions as FormattedAllowedMentions)
       : this.creator.allowedMentions;
@@ -221,7 +212,7 @@ export class MessageInteractionContext {
         embeds: options.embeds,
         allowed_mentions: allowedMentions,
         components: options.components,
-        attachments: resolvedAttachmentData
+        attachments: options.attachments
       },
       options.file
     );
@@ -418,7 +409,7 @@ export interface EditMessageOptions {
   /** The components of the message. */
   components?: ComponentActionRow[];
   /** The attachment data of the message. */
-  // attachments?: MessageAttachmentOptions[];
+  attachments?: MessageAttachmentOptions[];
 }
 
 /** A file within {@link EditMessageOptions}. */
@@ -428,17 +419,15 @@ export interface MessageFile {
   /** The name of the file. */
   name: string;
   /** The index of the file. */
-  id?: string | number;
-  /** The description of the file. */
-  description?: string;
+  id?: number;
 }
 
 /** A message attachment describing a file. */
 export interface MessageAttachmentOptions {
   /** The name of the attachment. */
-  name: string;
+  name?: string;
   /** The index of the attachment. */
-  id?: string;
+  id: string | number;
   /** The description of the attachment. */
   description?: string;
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,5 +1,4 @@
 import { ApplicationCommandOption, CommandOptionType } from './constants';
-import { MessageAttachmentOptions, MessageFile } from './structures/interfaces/messageInteraction';
 import nacl from 'tweetnacl';
 import fs from 'fs';
 import path from 'path';
@@ -143,17 +142,6 @@ export function getFiles(folderPath: string) {
 
 export function generateID() {
   return (Date.now() + Math.round(Math.random() * 1000)).toString(36);
-}
-
-export function formatAttachmentData(files?: MessageFile | MessageFile[]): MessageAttachmentOptions[] | undefined {
-  if (!files) return undefined;
-  if (!Array.isArray(files)) files = [files];
-
-  return files.map((file, index) => ({
-    id: (file.id ?? index).toString(),
-    name: file.name,
-    description: file.description
-  }));
 }
 
 /** The allowed mentions for a {@link Message}. */

--- a/src/util.ts
+++ b/src/util.ts
@@ -151,7 +151,8 @@ export function formatAttachmentData(files?: MessageFile | MessageFile[]): Messa
 
   return files.map((file, index) => ({
     id: `${index}`,
-    name: file.name
+    name: file.name,
+    description: file.description
   }));
 }
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,4 +1,5 @@
 import { ApplicationCommandOption, CommandOptionType } from './constants';
+import { MessageAttachmentOptions, MessageFile } from './structures/interfaces/messageInteraction';
 import nacl from 'tweetnacl';
 import fs from 'fs';
 import path from 'path';
@@ -142,6 +143,16 @@ export function getFiles(folderPath: string) {
 
 export function generateID() {
   return (Date.now() + Math.round(Math.random() * 1000)).toString(36);
+}
+
+export function formatAttachmentData(files?: MessageFile | MessageFile[]): MessageAttachmentOptions[] | undefined {
+  if (!files) return undefined;
+  if (!Array.isArray(files)) files = [files];
+
+  return files.map((file, index) => ({
+    id: `${index}`,
+    name: file.name
+  }));
 }
 
 /** The allowed mentions for a {@link Message}. */

--- a/src/util.ts
+++ b/src/util.ts
@@ -150,7 +150,7 @@ export function formatAttachmentData(files?: MessageFile | MessageFile[]): Messa
   if (!Array.isArray(files)) files = [files];
 
   return files.map((file, index) => ({
-    id: `${index}`,
+    id: (file.id ?? index).toString(),
     name: file.name,
     description: file.description
   }));

--- a/src/util/requestHandler.ts
+++ b/src/util/requestHandler.ts
@@ -102,18 +102,18 @@ export class RequestHandler {
             if (Array.isArray(file)) {
               data = new MultipartData();
               headers['Content-Type'] = 'multipart/form-data; boundary=' + data.boundary;
-              file.forEach((f) => {
+              file.forEach((f, index) => {
                 if (!f.file) {
                   return;
                 }
-                (data as MultipartData).attach(f.name, f.file, f.name);
+                (data as MultipartData).attach(`files[${f.id ?? index}]`, f.file, f.name);
               });
               if (body) data.attach('payload_json', body);
               data = data.finish();
             } else if (file.file) {
               data = new MultipartData();
               headers['Content-Type'] = 'multipart/form-data; boundary=' + data.boundary;
-              data.attach('file', file.file, file.name);
+              data.attach(`files[${file.id ?? 0}]`, file.file, file.name);
               if (body) data.attach('payload_json', body);
               data = data.finish();
             } else {

--- a/test/structures/interfaces/messageInteraction.ts
+++ b/test/structures/interfaces/messageInteraction.ts
@@ -84,7 +84,8 @@ describe('MessageInteractionContext', () => {
             embeds: undefined,
             flags: undefined,
             tts: undefined,
-            components: undefined
+            components: undefined,
+            attachments: undefined
           }
         });
         expect(treq.status).to.equal(200);
@@ -106,7 +107,8 @@ describe('MessageInteractionContext', () => {
             embeds: undefined,
             flags: InteractionResponseFlags.EPHEMERAL,
             tts: undefined,
-            components: undefined
+            components: undefined,
+            attachments: undefined
           }
         });
         expect(treq.status).to.equal(200);


### PR DESCRIPTION
* remains to be fully tested, and documented
* initial tests reveal attachments may need to retain original attachment IDs from the sent message
* specifying `attachments` as part of the message body, removes the ability to auto resolve attachment indexes

- [x] Test suite (`.send`, ~~`.sendFollowUp`~~)
- [ ] Active deployment test

<details>
<summary>Possible command for deployment test</summary>

```ts
import { CommandContext, SlashCommand, SlashCreator } from 'slash-create';

export default class FileTestCommand extends SlashCommand {
  constructor(creator: SlashCreator) {
    super(creator, {
      name: 'file-test',
      description: 'Test file upload'
    });
  }

  async run(ctx: CommandContext) {
    await ctx.defer();
    await ctx.send({
      content: "Here's a file!",
      file: {
        name: 'test.txt',
        file: Buffer.from('This is a test file.')
      }
    });

    await ctx.editOriginal({
      content: "Here's another file!",
      attachments: [
        {
          id: '0',
          name: 'test.txt'
        },
        {
          id: '1',
          name: 'test2.txt'
        }
      ],
      file: {
        name: 'test2.txt',
        file: Buffer.from('This is another test file.')
      }
    });
  }
}
```
</details>

> `Invalid form data` error originates from the edit attempt not having an ID attached to the file - due to how it utilizes attachments when building multipart data.