### PR TITLE
patch: reflect changes from #358 onto server responses

### DIFF
--- a/src/servers/azure.ts
+++ b/src/servers/azure.ts
@@ -36,7 +36,7 @@ export class AzureFunctionServer extends Server {
         if (response.files) {
           const data = new MultipartData();
           context.res!.header('Content-Type', 'multipart/form-data; boundary=' + data.boundary);
-          for (const file of response.files) data.attach(file.name, file.file, file.name);
+          for (const i in response.files) data.attach(`files[${i}]`, response.files[i].file, response.file[i].name);
           data.attach('payload_json', JSON.stringify(response.body));
           context.res!.send(Buffer.concat(data.finish()));
         } else {

--- a/src/servers/express.ts
+++ b/src/servers/express.ts
@@ -68,7 +68,7 @@ export class ExpressServer extends Server {
           if (response.files) {
             const data = new MultipartData();
             res.set('Content-Type', 'multipart/form-data; boundary=' + data.boundary);
-            for (const file of response.files) data.attach(file.name, file.file, file.name);
+            for (const i in response.files) data.attach(`files[${i}]`, response.files[i].file, response.file[i].name);
             data.attach('payload_json', JSON.stringify(response.body));
             res.send(Buffer.concat(data.finish()));
           } else res.send(response.body);

--- a/src/servers/fastify.ts
+++ b/src/servers/fastify.ts
@@ -67,7 +67,7 @@ export class FastifyServer extends Server {
           if (response.files) {
             const data = new MultipartData();
             res.header('Content-Type', 'multipart/form-data; boundary=' + data.boundary);
-            for (const i in response.files) data.attach(`files[${i}]`, file[i].file, file[i].name);
+            for (const i in response.files) data.attach(`files[${i}]`, response.files[i].file, response.file[i].name);
             data.attach('payload_json', JSON.stringify(response.body));
             res.send(Buffer.concat(data.finish()));
           } else res.send(response.body);

--- a/src/servers/fastify.ts
+++ b/src/servers/fastify.ts
@@ -67,7 +67,7 @@ export class FastifyServer extends Server {
           if (response.files) {
             const data = new MultipartData();
             res.header('Content-Type', 'multipart/form-data; boundary=' + data.boundary);
-            for (const file of response.files) data.attach(file.name, file.file, file.name);
+            for (const i in response.files) data.attach(`files[${i}]`, file[i].file, file[i].name);
             data.attach('payload_json', JSON.stringify(response.body));
             res.send(Buffer.concat(data.finish()));
           } else res.send(response.body);

--- a/src/servers/gcf.ts
+++ b/src/servers/gcf.ts
@@ -35,7 +35,7 @@ export class GCFServer extends Server {
         if (response.files) {
           const data = new MultipartData();
           res.set('Content-Type', 'multipart/form-data; boundary=' + data.boundary);
-          for (const i in response.files) data.attach(`files[${i}]`, file[i].file, file[i].name);
+          for (const i in response.files) data.attach(`files[${i}]`, response.files[i].file, response.file[i].name);
           data.attach('payload_json', JSON.stringify(response.body));
           res.send(Buffer.concat(data.finish()));
         } else res.send(response.body);

--- a/src/servers/gcf.ts
+++ b/src/servers/gcf.ts
@@ -35,7 +35,7 @@ export class GCFServer extends Server {
         if (response.files) {
           const data = new MultipartData();
           res.set('Content-Type', 'multipart/form-data; boundary=' + data.boundary);
-          for (const file of response.files) data.attach(file.name, file.file, file.name);
+          for (const i in response.files) data.attach(`files[${i}]`, file[i].file, file[i].name);
           data.attach('payload_json', JSON.stringify(response.body));
           res.send(Buffer.concat(data.finish()));
         } else res.send(response.body);

--- a/src/servers/lambda.ts
+++ b/src/servers/lambda.ts
@@ -43,7 +43,7 @@ export class AWSLambdaServer extends Server {
         if (response.files) {
           const data = new MultipartData();
           responseHeaders['Content-Type'] = 'multipart/form-data; boundary=' + data.boundary;
-          for (const i in response.files) data.attach(`files[${i}]`, file[i].file, file[i].name);
+          for (const i in response.files) data.attach(`files[${i}]`, response.files[i].file, response.file[i].name);
           data.attach('payload_json', JSON.stringify(response.body));
           callback(null, {
             statusCode: response.status || 200,

--- a/src/servers/lambda.ts
+++ b/src/servers/lambda.ts
@@ -43,7 +43,7 @@ export class AWSLambdaServer extends Server {
         if (response.files) {
           const data = new MultipartData();
           responseHeaders['Content-Type'] = 'multipart/form-data; boundary=' + data.boundary;
-          for (const file of response.files) data.attach(file.name, file.file, file.name);
+          for (const i in response.files) data.attach(`files[${i}]`, file[i].file, file[i].name);
           data.attach('payload_json', JSON.stringify(response.body));
           callback(null, {
             statusCode: response.status || 200,

--- a/src/servers/vercel.ts
+++ b/src/servers/vercel.ts
@@ -32,7 +32,7 @@ export class VercelServer extends Server {
         if (response.files) {
           const data = new MultipartData();
           res.setHeader('Content-Type', 'multipart/form-data; boundary=' + data.boundary);
-          for (const file of response.files) data.attach(file.name, file.file, file.name);
+          for (const i in response.files) data.attach(`files[${i}]`, response.files[i].file, response.file[i].name);
           data.attach('payload_json', JSON.stringify(response.body));
           res.send(Buffer.concat(data.finish()));
         } else res.send(response.body);


### PR DESCRIPTION
Carries over from #358 to correct `400: Invalid Form Error` on initial response.

This could have been done one of three ways:

```ts
for (const i in response.files) data.attach(`files[${i}]`, response.files[i].file, response.file[i].name); // 1 **
for (const [i, file] in response.files.entries()) data.attach(`files[${i}]`, file.file, file.name); // 2
// ---
let index = 0;
for (const file of response.files) data.attach(`files[${index++}]`, file.file, file.name); // 3
```
