### PR TITLE
feat: register global modals

### DIFF
--- a/docs/examples/components.md
+++ b/docs/examples/components.md
@@ -176,6 +176,46 @@ module.exports = class HelloCommand extends SlashCommand {
 
 ```
 
+
+### Global Modal
+
+Global modal allow action callbacks to be registered when the bot starts up, thus creating reproductible responses no matter how much time has passed since the message was sent.
+They are quite useful for server welcome messages, for example.
+
+```typescript
+module.exports = class HelloCommand extends SlashCommand {
+  constructor(creator: SlashCreator) {
+    super(creator, {
+      name: 'aeon',
+
+      description: 'Says hello to you.',
+      options: []
+    });
+
+    // Since this is registered globally in the constructor, it will remain the same forever.
+    creator.registerGlobalModal('hello', (interact) => {
+      interact.sendFollowUp(`Hello ${interact.values.name}, This modal will never expire!`);
+    })
+  }
+
+
+  async run(ctx: CommandContext) {
+    return ctx.sendModal({
+      title: 'Welcome',
+      custom_id: 'hello',
+      componenets: [{type: ComponentType.ACTION_ROW, components: [{type: ComponentType.TEXT_INPUT,
+        custom_id: 'name',
+        placeholder: 'What is your name?',
+        label: 'Name',
+        style: TextInputStyle.SHORT,
+        required: true,
+      }]}]
+    })
+  }
+}
+
+```
+
 ### Expirations and Callbacks
 You can also set a custom expiration time for your components, and register a callback to be called when the component expires.
 Note that such callbacks are only called when the component receives an invokation after the expiration time has elapsed, not instantly when the component expires.

--- a/src/creator.ts
+++ b/src/creator.ts
@@ -558,6 +558,30 @@ export class SlashCreator extends (EventEmitter as any as new () => TypedEventEm
   }
 
   /**
+   * Registers a global modal callback. Note that this will have no expiration, and should be invoked by the returned name.
+   * @param custom_id The custom ID of the modal to register
+   * @param callback The callback to use on interaction
+   */
+  registerGlobalModal(custom_id: string, callback: ModalRegisterCallback) {
+    const newName = `global-${custom_id}`;
+    if (this._modalCallbacks.has(newName))
+      throw new Error(`A global model with the ID "${newName}" is already registered.`);
+    this._modalCallbacks.set(newName, {
+      callback,
+      expires: undefined,
+      onExpired: undefined
+    });
+  }
+
+  /**
+   * Unregisters a global modal callback.
+   * @param custom_id The custom ID of the component to unregister
+   */
+  unregisterGlobalModal(custom_id: string) {
+    return this._modalCallbacks.delete(`global-${custom_id}`);
+  }
+
+  /**
    * Cleans any awaiting component callbacks from command contexts.
    */
   cleanRegisteredComponents() {

--- a/src/creator.ts
+++ b/src/creator.ts
@@ -820,11 +820,15 @@ export class SlashCreator extends (EventEmitter as any as new () => TypedEventEm
           this.cleanRegisteredComponents();
 
           const modalCallbackKey = `${context.user.id}-${context.customID}`;
+          const globalCallbackKey = `global-${context.customID}`;
           if (this._modalCallbacks.has(modalCallbackKey)) {
             this._modalCallbacks.get(modalCallbackKey)!.callback(context);
             this._modalCallbacks.delete(modalCallbackKey);
             return;
           }
+          if (this._modalCallbacks.has(globalCallbackKey))
+            this._modalCallbacks.get(modalCallbackKey)!.callback(context);
+
           return;
         } catch (err) {
           return this.emit('error', err as Error);


### PR DESCRIPTION
## Changes
added method SlashCreator#registerGlobalModal 
added method SlashCreator#unregisterGlobalModal
modified method SlashCreator#_onInteraction to search using global callback key
example created for global modal under docs/examples/components.md


