### PR TITLE
fix: fix GUILD_FORUM enum value

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -123,7 +123,7 @@ export enum ChannelType {
   /** The channel in a hub containing the listed servers. */
   GUILD_DIRECTORY = 14,
   /** A channel that can only contain threads. */
-  GUILD_FORUM = 13
+  GUILD_FORUM = 15
 }
 
 /**


### PR DESCRIPTION
Took me a few to figure out why the `channel_types` command option wasn't including forums.

See [Channel Types](https://discord.com/developers/docs/resources/channel#channel-object-channel-types).