### PR TITLE
chore: Changes access control on key internal methods.

### DIFF
--- a/src/creator.ts
+++ b/src/creator.ts
@@ -599,7 +599,7 @@ export class SlashCreator extends (EventEmitter as any as new () => TypedEventEm
       : this.commands.get(`${interaction.data.type}:global:${interaction.data.name}`);
   }
 
-  private async _onRequest(treq: TransformedRequest, respond: RespondFunction) {
+  protected async _onRequest(treq: TransformedRequest, respond: RespondFunction) {
     this.emit('debug', 'Got request');
     this.emit('rawRequest', treq);
 
@@ -640,7 +640,7 @@ export class SlashCreator extends (EventEmitter as any as new () => TypedEventEm
     } catch (e) {}
   }
 
-  private async _onInteraction(interaction: AnyRequestData, respond: RespondFunction | null, webserverMode: boolean) {
+  protected async _onInteraction(interaction: AnyRequestData, respond: RespondFunction | null, webserverMode: boolean) {
     this.emit('rawInteraction', interaction);
 
     if (!respond || !webserverMode) respond = this._createGatewayRespond(interaction.id, interaction.token);

--- a/src/util/requestHandler.ts
+++ b/src/util/requestHandler.ts
@@ -34,7 +34,7 @@ export class RequestHandler {
   readonly readyQueue: any[] = [];
 
   /** The creator that initialized the handler. */
-  private _creator: SlashCreator;
+  protected _creator: SlashCreator;
 
   /** @param creator The instantiating creator. */
   constructor(creator: SlashCreator) {


### PR DESCRIPTION
This patch opens up some private methods, specifically: RequestHandler._creator
Creator._onRequest
Creator._onInteraction
This patch is required for the CF worker to be typesafe.