### PR TITLE
fix(user): correct default avatar index

### DIFF
--- a/src/structures/user.ts
+++ b/src/structures/user.ts
@@ -60,7 +60,7 @@ export class User {
 
   /** The hash for the default avatar of a user if there is no avatar set. */
   get defaultAvatar() {
-    if (this.discriminator === '0') return Number((BigInt(this.id) >> 22n) % 5n);
+    if (this.discriminator === '0') return Number((BigInt(this.id) >> 22n) % 6n);
     return parseInt(this.discriminator) % 5;
   }
 


### PR DESCRIPTION
As documented under [Image Formatting](https://discord.com/developers/docs/reference#image-formatting), users on the new username system can use the previously unused sixth default avatar. This PR corrects `User#defaultAvatar` to account for this.