### PR TITLE
Removed debug logging

### DIFF
--- a/src/structures/message.ts
+++ b/src/structures/message.ts
@@ -60,7 +60,6 @@ export class Message {
   constructor(data: MessageData, creator: BaseSlashCreator, ctx?: MessageInteractionContext) {
     if (ctx) this._ctx = ctx;
 
-    console.log(data);
     this.id = data.id;
     this.type = data.type;
     this.content = data.content;


### PR DESCRIPTION
Seems like during the development of the latest update (User-Installable Apps) the debug logging was not removed before the release. This now spams the console with every interaction and should be removed again.