### PR TITLE
Update undici dependency version

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "eventemitter3": "^5.0.1",
     "lodash.isequal": "^4.5.0",
     "tweetnacl": "^1.0.3",
-    "undici": "5.28.2"
+    "undici": "^5.28.4 || ^6.11.1"
   },
   "devDependencies": {
     "@microsoft/eslint-formatter-sarif": "^3.0.0",


### PR DESCRIPTION
# UNTESTED PR

This change would fix Deprecated Undici dependency #611.
I suspect this change should not break anything based on the GH discussion screen shot shown in that issue.
Nonetheless, I have not tested the changes in this PR to ensure that they work correctly.