### PR TITLE
chore: update permissions description

### DIFF
--- a/src/structures/channel.ts
+++ b/src/structures/channel.ts
@@ -104,7 +104,7 @@ export class Channel {
     return `<#${this.id}>`;
   }
 
-  /** The permissions the application has in the channel. */
+  /** The computed permissions for the invoking user in the channel, including overwrites, excluding implicit permissions. */
   get permissions() {
     if (!this._permissions) return null;
     if (!this._permissionsBitfield) this._permissionsBitfield = new Permissions(BigInt(this._permissions));


### PR DESCRIPTION
The permissions field of the channel contains the permissions of the invoking user in the channel and not of the application.

See https://discord.com/developers/docs/resources/channel#channel-object-channel-structure