### PR TITLE
feat: export utils

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ export * from './creator';
 export * from './server';
 
 export * from './node/creator';
+export * from './node/util';
 
 export * from './util/bitfield';
 export * from './util/collection';


### PR DESCRIPTION
I am using a somewhat modified version of Slash-Create to support multi-token bots. To avoid extra maintenance I simply leverage JS to modify methods, specifically, the `_onRequest` handler.

I bring my own slightly modified version of the method in a dedicated file and override the method and binds. However, this request handler method depends on the `verifyKey` utility.

It would be nice if it was also exported so I could simply import via something like this
```ts
// In my onRequest.ts
import { verifyKey } from "slash-create";

// ... rest of the _onRequest() handler, with modifications
```