### PR TITLE
feat: added premium button

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -50,7 +50,10 @@ export enum InteractionResponseType {
   APPLICATION_COMMAND_AUTOCOMPLETE_RESULT = 8,
   /** Respond to an interaction with a popup modal. */
   MODAL = 9,
-  /** Respond to an interaction with prompt for a premium subscription. */
+  /**
+   * Respond to an interaction with prompt for a premium subscription.
+   * @deprecated Use `ComponentButtonPremium` instead.
+   */
   PREMIUM_REQUIRED = 10
 }
 
@@ -870,7 +873,9 @@ export enum ButtonStyle {
   /** A red button. */
   DANGER = 4,
   /** A gray button with a link icon. */
-  LINK = 5
+  LINK = 5,
+  /** A premium button. */
+  PREMIUM = 6
 }
 
 export enum TextInputStyle {
@@ -892,7 +897,7 @@ export interface ComponentActionRow {
 }
 
 /** Any component button. */
-export type AnyComponentButton = ComponentButton | ComponentButtonLink;
+export type AnyComponentButton = ComponentButton | ComponentButtonLink | ComponentButtonPremium;
 
 /** A regular component button. */
 export interface ComponentButton {
@@ -921,6 +926,14 @@ export interface ComponentButtonLink extends Omit<ComponentButton, 'custom_id' |
   style: ButtonStyle.LINK;
   /** The URL for link buttons. */
   url: string;
+}
+
+/** A component button with a premium sku. */
+export interface ComponentButtonPremium extends Omit<ComponentButton, 'custom_id' | 'label' | 'emoji' | 'style'> {
+  /** The style of button to show. */
+  style: ButtonStyle.PREMIUM;
+  /** The identifier for a purchasable SKU. */
+  sku_id: string;
 }
 
 export interface ComponentSelectMenu {

--- a/src/structures/interfaces/messageInteraction.ts
+++ b/src/structures/interfaces/messageInteraction.ts
@@ -212,6 +212,7 @@ export class MessageInteractionContext extends BaseInteractionContext {
   /**
    * Creates a message that prompts the user for a premium subscription.
    * @returns Whether the message passed
+   * @deprecated Use `ComponentButtonPremium` instead.
    */
   async promptPremium(): Promise<boolean> {
     if (!this.initiallyResponded && !this.deferred) {


### PR DESCRIPTION
- Added new premium button style
- Marked `PREMIUM_REQUIRED (10)` interaction response type as deprecated

Refs:
- https://github.com/discord/discord-api-docs/pull/6875
- https://discord.com/developers/docs/change-log#premium-apps-new-premium-button-style-deep-linking-url-schemes