### PR TITLE
fix(user): global modal submit handlers causing internal errors

### DIFF
--- a/src/creator.ts
+++ b/src/creator.ts
@@ -732,10 +732,9 @@ export class BaseSlashCreator extends (EventEmitter as any as new () => TypedEve
           if (this._modalCallbacks.has(modalCallbackKey)) {
             this._modalCallbacks.get(modalCallbackKey)!.callback(ctx);
             this._modalCallbacks.delete(modalCallbackKey);
-            return;
+          } else if (this._modalCallbacks.has(globalCallbackKey)) {
+            this._modalCallbacks.get(globalCallbackKey)!.callback(ctx);
           }
-          if (this._modalCallbacks.has(globalCallbackKey)) this._modalCallbacks.get(modalCallbackKey)!.callback(ctx);
-
           return;
         } catch (err) {
           return this.emit('error', err as Error);


### PR DESCRIPTION
A typo caused slash-create to throw internal errors if a modal was submitted and a global modal submit handler was registered - The code checks whether `globalCallbackKey` exists in `_modalCallbacks`, but then tries to access `modalCallbackKey` in `_modalCallbacks`.

Fixing the typo allows developers to use `creator.registerGlobalModal` again.