### PR TITLE
feat(constants): Added GUILD_MEDIA channel type

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -140,7 +140,9 @@ export enum ChannelType {
   /** The channel in a hub containing the listed servers. */
   GUILD_DIRECTORY = 14,
   /** A channel that can only contain threads. */
-  GUILD_FORUM = 15
+  GUILD_FORUM = 15,
+  /** A channel where media can be posted. Can only contain threads, similar to GUILD_FORUM channels. */
+  GUILD_MEDIA = 16
 }
 
 /** The formats that stickers can be in. */


### PR DESCRIPTION
It's still on development, but discord.js already has it. Would be nice to have it in slash-create too. More info on [https://discord.com/developers/docs/resources/channel#channel-object-channel-types](https://discord.com/developers/docs/resources/channel#channel-object-channel-types)