### PR TITLE
Don't force `express.json()` on the entire Express app

### DIFF
--- a/src/servers/express.ts
+++ b/src/servers/express.ts
@@ -22,7 +22,6 @@ export class ExpressServer extends Server {
     if (!app) {
       if (!express) throw new Error('You must have the `express` package installed before using this server.');
       app = express();
-      app.use(express.json());
     }
     this.app = app;
   }
@@ -31,6 +30,7 @@ export class ExpressServer extends Server {
   createEndpoint(path: string, handler: ServerRequestHandler) {
     this.app.post(
       path,
+      express.json(),
       (req: any, res: any) =>
         void handler(
           {


### PR DESCRIPTION
I found this pitfall when working on one of my projects where I use Stripe webhooks, and the HTTP bodies they send have to be read in raw into `Buffer`s for crypto-related & signing purposes. So I can't attach a body parser to my Express app globally, and I don't want to have two distinct Express apps. This change allows more flexibility with Express.