### PR TITLE
Change Azure Function Server to V4 programming model

### DIFF
--- a/src/servers/azure.ts
+++ b/src/servers/azure.ts
@@ -1,6 +1,6 @@
 import { Server, ServerRequestHandler } from '../server';
 // @ts-ignore
-import type { Context, HttpRequest } from '@azure/functions';
+import type { InvocationContext, HttpRequest, HttpResponseInit } from '@azure/functions';
 import { MultipartData } from '../util/multipartData';
 
 /**
@@ -10,42 +10,53 @@ import { MultipartData } from '../util/multipartData';
 export class AzureFunctionServer extends Server {
   private _handler?: ServerRequestHandler;
 
-  constructor(moduleExports: any, target = 'interactions') {
+  constructor(app: any, target = 'interactions') {
     super({ alreadyListening: true });
-    moduleExports[target] = this._onRequest.bind(this);
+    app.http("interactions", {
+      methods: ['POST'],
+      authLevel: 'anonymous',
+      route: target,
+      handler: this._onRequest.bind(this)
+    });
   }
 
-  private _onRequest(context: Context, req: HttpRequest) {
-    if (!this._handler) {
-      context.res!.status = 503;
-      context.res!.send('Server has no handler');
-    }
-    if (req.method !== 'POST') {
-      context.res!.status = 400;
-      context.res!.send('Server only supports POST requests.');
-    }
-    this._handler!(
-      {
-        headers: req.headers,
-        body: req.body,
-        request: req,
-        response: context.res
-      },
-      async (response) => {
-        context.res!.status = response.status || 200;
-        if (response.files) {
-          const data = new MultipartData();
-          context.res!.header('Content-Type', 'multipart/form-data; boundary=' + data.boundary);
-          for (const i in response.files) data.attach(`files[${i}]`, response.files[i].file, response.files[i].name);
-          data.attach('payload_json', JSON.stringify(response.body));
-          context.res!.send(Buffer.concat(data.finish()));
-        } else {
-          context.res!.header('Content-Type', 'application/json');
-          context.res!.send(response.body);
+  private async _onRequest(request: HttpRequest, context: InvocationContext): Promise<HttpResponseInit> {
+    if (!this._handler) return { status: 503, body: 'Server has no handler'}
+    if (request.method !== 'POST') return { status: 400, body: 'Server only supports POST requests.' }
+    const body = await request.text();
+    return new Promise((resolve, reject) => {
+      this._handler!(
+        {
+          headers: Object.fromEntries(request.headers.entries()),
+          body: body ? JSON.parse(body) : body,
+          request: request,
+          response: null
+        },
+        async (response) => {
+          if (response.files) {
+            const data = new MultipartData();
+            for (const i in response.files) data.attach(`files[${i}]`, response.files[i].file, response.files[i].name);
+            data.attach('payload_json', JSON.stringify(response.body));
+            resolve(
+              {
+                status: response.status || 200,
+                headers: { 'Content-Type': `multipart/form-data; boundary=${data.boundary}` },
+                body: Buffer.concat(data.finish())
+              }
+            );
+          } else {
+            resolve(
+              {
+                status: response.status || 200,
+                headers: { 'Content-Type': 'application/json' },
+                jsonBody: response.body
+              }
+            );
+          }
         }
-      }
-    );
-  }
+      ).catch(reject);
+    }) as Promise<any>;
+  };
 
   /** @private */
   createEndpoint(path: string, handler: ServerRequestHandler) {


### PR DESCRIPTION
- **(Breaking)** Changed parameters into AzureFunctionServer to accept app instead of module exports.
- Changed `_OnRequest` function signiture.
- Updated `Treq` transformation for new request formatting.
- `_OnRequest` now returns a response JSON rather than using `Context.res`.