### PR TITLE
docs(readme): add users info

### DIFF
--- a/.github/workflows/dependents.yml
+++ b/.github/workflows/dependents.yml
@@ -1,0 +1,16 @@
+name: Dependents Action
+
+on:
+  push:
+    branches: [master]
+  schedule:
+    - cron: "0 0 1 * *"
+  workflow_dispatch:
+
+jobs:
+  dependents:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    steps:
+      - uses: gouravkhunger/dependents.info@0.1.4

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <img src="/static/textlogo.png" height="50">
 
-[![NPM version](https://img.shields.io/npm/v/slash-create?maxAge=3600)](https://www.npmjs.com/package/slash-create) [![NPM downloads](https://img.shields.io/npm/dt/slash-create?maxAge=3600)](https://www.npmjs.com/package/slash-create) [![ESLint status](https://github.com/Snazzah/slash-create/workflows/ESLint/badge.svg)](https://github.com/Snazzah/slash-create/actions?query=workflow%3A%22ESLint%22) [![DeepScan grade](https://deepscan.io/api/teams/11596/projects/15103/branches/297399/badge/grade.svg)](https://deepscan.io/dashboard#view=project&tid=11596&pid=15103&bid=297399) [![discord chat](https://img.shields.io/discord/311027228177727508?logo=discord&logoColor=white)](https://snaz.in/discord)
+[![NPM version](https://img.shields.io/npm/v/slash-create?maxAge=3600)](https://www.npmjs.com/package/slash-create) [![NPM downloads](https://img.shields.io/npm/dt/slash-create?maxAge=3600)](https://www.npmjs.com/package/slash-create) [![Network Dependents](https://dependents.info/Snazzah/slash-create/badge)](https://dependents.info/Snazzah/slash-create) [![ESLint status](https://github.com/Snazzah/slash-create/workflows/ESLint/badge.svg)](https://github.com/Snazzah/slash-create/actions?query=workflow%3A%22ESLint%22) [![DeepScan grade](https://deepscan.io/api/teams/11596/projects/15103/branches/297399/badge/grade.svg)](https://deepscan.io/dashboard#view=project&tid=11596&pid=15103&bid=297399) [![discord chat](https://img.shields.io/discord/311027228177727508?logo=discord&logoColor=white)](https://snaz.in/discord)
 
 Create and sync [Discord slash commands](https://discord.com/developers/docs/interactions/application-commands).
 


### PR DESCRIPTION
Hi there!

Thank you for this awesome project! This PR adds a relevant auto-updated shields.io style network dependents badge and the image in the `README.md` file to showcase its impact.

I've created this using an [open source](https://github.com/gouravkhunger/dependents.info) tool I built some time ago and plan to maintain for long. It also creates an image preview of the users in the readme.

Here's how they would look for your repository:

<img width="687" alt="image" src="https://github.com/user-attachments/assets/c4b11b17-74ce-45d6-b646-db4555666eff" />
<br /><br />

I haven't included the full image yet, but I can update the PR if you think it'll be good. [Here's](https://github.com/joshnuss/svelte-persisted-store) a project using it already.

Please feel free to close the PR if you don't want to have this!