### PR TITLE
chore(types): improve on select types

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1301,8 +1301,6 @@ export interface ComponentStringSelect extends ComponentSelectBase {
 
 export interface ComponentChannelSelect extends ComponentSelectBase {
   type: ComponentType.CHANNEL_SELECT;
-  /** The options to show inside this menu. Only used for string selects. */
-  options: ComponentSelectOption[];
   /** An array of channel types this select can use. Only used for channel selects. */
   channel_types?: ChannelType[];
   /** An array of default values. */

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1293,7 +1293,7 @@ export interface ComponentSelectBase {
 
 export interface ComponentStringSelect extends ComponentSelectBase {
   type: ComponentType.STRING_SELECT;
-  /** The options to show inside this menu. Only used for string selects. */
+  /** The options to show inside this menu. */
   options: ComponentSelectOption[];
   /** Whether this component is required. Only used in modals. */
   required?: boolean;
@@ -1301,7 +1301,7 @@ export interface ComponentStringSelect extends ComponentSelectBase {
 
 export interface ComponentChannelSelect extends ComponentSelectBase {
   type: ComponentType.CHANNEL_SELECT;
-  /** An array of channel types this select can use. Only used for channel selects. */
+  /** An array of channel types this select can use. */
   channel_types?: ChannelType[];
   /** An array of default values. */
   default_values?: SelectDefaultValue[];

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1279,7 +1279,7 @@ export interface ComponentSelectBase {
     | ComponentType.CHANNEL_SELECT;
   /** Optional component identifier */
   id?: number;
-  /** The identifier of the of the menu. */
+  /** The identifier of the of the select. */
   custom_id: string;
   /** The string to show in absence of a selected option. */
   placeholder?: string;
@@ -1287,13 +1287,13 @@ export interface ComponentSelectBase {
   min_values?: number;
   /** The maximum number of items to be chosen. */
   max_values?: number;
-  /** Whether this menu will show as disabled. */
+  /** Whether this select will show as disabled. */
   disabled?: boolean;
 }
 
 export interface ComponentStringSelect extends ComponentSelectBase {
   type: ComponentType.STRING_SELECT;
-  /** The options to show inside this menu. */
+  /** The options to show inside this select. */
   options: ComponentSelectOption[];
   /** Whether this component is required. Only used in modals. */
   required?: boolean;


### PR DESCRIPTION
`options` is not available for Channel Selects