### PR TITLE
fix(rest): infinite retry loop on repeated 429 rate limit responses

### DIFF
--- a/src/rest/sequentialBucket.ts
+++ b/src/rest/sequentialBucket.ts
@@ -179,6 +179,9 @@ export class SequentialBucket {
     if (res.status >= 400 && res.status < 500) {
       const data: any = await parseResponse(res);
       if (res.status === 429) {
+        if (attempts >= this.#handler.options.retryLimit!)
+          throw new DiscordRESTError(request, res, data, stackHolder.stack);
+
         const delay = data?.retry_after ? data.retry_after * 1000 : retryAfter;
         this.#handler.creator?.emit(
           'debug',
@@ -187,7 +190,7 @@ export class SequentialBucket {
 
         if (delay) await Mutex.wait(delay);
 
-        return this.#execute(request, attempts);
+        return this.#execute(request, ++attempts);
       }
 
       throw new DiscordRESTError(request, res, data, stackHolder.stack);


### PR DESCRIPTION
Fixes https://github.com/Snazzah/slash-create/issues/650

### Changes
- Added `retryLimit` check to the 429 handler in `SequentialBucket#execute` to throw a `DiscordRESTError` when the limit is reached
- Incremented `attempts` counter on 429 retries so the retry limit is actually tracked