### PR TITLE
chore: fix typo "recieve" → "receive" in api.ts JSDoc

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -175,7 +175,7 @@ export class SlashCreatorAPI {
    * @param interactionToken The interaction's token.
    * @param body The body to send.
    * @param files The files to send.
-   * @param withResponse Whether to recieve the response of the interaction callback
+   * @param withResponse Whether to receive the response of the interaction callback
    */
   interactionCallback<WithResponse extends boolean = false>(
     interactionID: string,


### PR DESCRIPTION
JSDoc-only typo fix on `@param withResponse` description in `src/api.ts`. No behavior change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected API documentation for improved accuracy and clarity.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Snazzah/slash-create/pull/652)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->